### PR TITLE
Frontend category endpoint

### DIFF
--- a/client/src/features/apiSlice.ts
+++ b/client/src/features/apiSlice.ts
@@ -12,6 +12,15 @@ interface InventoryReport {
   monthly_api_usage: number;
 }
 
+interface Category { 
+  category_name: string; //name of the category to be added as a string for the Category object
+}
+
+interface CategoryResponse {
+  success: boolean; // true/false if the category was added successfully in backend/server
+  data: Category // added Category object
+}
+
 export const apiSlice = createApi({
   reducerPath: 'api',
   baseQuery: fetchBaseQuery({
@@ -23,8 +32,18 @@ export const apiSlice = createApi({
     }),
     getInventory: builder.query<InventoryReport, void>({
       query: () => 'reports/inventory'
+    }),
+    //mutation used for POST requests to server/backend.
+    //CategoryResponse = expected response from server/backend
+    //Category = category_name to be sent to server/backend
+    addCategory: builder.mutation<CategoryResponse, Category>({
+      query: (new_category_name) => ({
+        url: 'category',
+        method: 'POST',
+        body: new_category_name
+      })
     })
   })
 });
 
-export const { useGetPingQuery, useGetInventoryQuery } = apiSlice;
+export const { useGetPingQuery, useGetInventoryQuery, useAddCategoryMutation } = apiSlice;

--- a/server/src/routers/categoryRouter.ts
+++ b/server/src/routers/categoryRouter.ts
@@ -4,7 +4,7 @@ import { AddingCategoryFunction } from "../database/database_handler";
 const router = Router();
 
 router.post('/', (req, res) => {
-    const category_name = req.body.category // extracting category_name for request body
+    const { category_name } = req.body // extracting category_name from request body as string
 
     AddingCategoryFunction(category_name)
         .then(data => res.json(data)) // sending back confirmation message to client/frontend that category has been added


### PR DESCRIPTION
The following merge should provide necessary functionality related to:

- [Function to front for communicating with backend no. 99](https://github.com/orgs/ohtu-megasense/projects/2/views/2?pane=issue&itemId=98744328&issue=ohtu-megasense%7Cerp%7C99)

The functionality has been verified in an E2E test in following way:
- The Drawer.tsx was modifed quick and dirty so that a textbox appears in the sidebar in the frontend where the user can type the new category name to be added and after the button is pressed it is sent to backend for creating an empty table with that name. Attached the used and Drawer.tsx. NB! The attached Drawer.tsx is not part of this PR, because it is not properly integrated into the current modular frontend.
- in one terminal `docker compose up` on the branch proposed for merging (fe_category_endpoint).
- in another terminal `docker exec -it postgres psql -U postgres` on the branch proposed for merging (fe_category_endpoint) seems to create the table correctly as well (see attachment)

[drawer.pdf](https://github.com/user-attachments/files/18929768/drawer.pdf)
[PostgreSQL added table exampleCategory2.pdf](https://github.com/user-attachments/files/18929791/PostgreSQL.added.table.exampleCategory2.pdf)
