### PR TITLE
add poll and watch to make used IDE irrelevant

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "test-api": "cross-env NODE_ENV=test node --import tsx --test test/api/**/*Test.ts",
     "test-unit": "cross-env NODE_ENV=test node --import tsx --test 'test/unit/**/*Test.ts'",
-    "dev": "cross-env NODE_ENV=development DEBUG=express:* ts-node-dev --respawn --transpile-only ./src/index.ts",
+    "dev": "cross-env NODE_ENV=development DEBUG=express:* ts-node-dev --respawn --transpile-only --watch src --poll ./src/index.ts",
     "build": "tsc",
     "lint": "eslint .",
     "prettier": "prettier --config .prettierrc 'src/**/*.ts' --write"


### PR DESCRIPTION
Fix so that used IDE does not affect that hot reload works. Eralier checked that this worked, but now checking if tests will pass when Plawright tests in Github has been updated.