### PR TITLE
Frontend: + button for new columns to existing table

### DIFF
--- a/client/src/components/categories/manage/CategoryManager.tsx
+++ b/client/src/components/categories/manage/CategoryManager.tsx
@@ -13,9 +13,13 @@ import { Category } from '../../../../../shared/types';
 
 interface CategoryManagerProps {
   category: Category;
+  // ATTEMPT TO RENDER NEW COLUMN NAME STARTS
+  refetchCategories: () => void;
+  // ATTEMPT TO RENDER NEW COLUMN NAME ENDS
 }
-
-export const CategoryManager = ({ category }: CategoryManagerProps) => {
+// ATTEMPT TO RENDER NEW COLUMN NAME STARTS
+export const CategoryManager = ({ category, refetchCategories }: CategoryManagerProps) => {
+// ATTEMPT TO RENDER NEW COLUMN NAME ENDS
   const [isEditing, setIsEditing] = useState(false);
   const [isAdding, setIsAdding] = useState(false);
   const tableRef = useRef<{
@@ -98,6 +102,9 @@ export const CategoryManager = ({ category }: CategoryManagerProps) => {
             category={category}
             isEditing={isEditing}
             ref={tableRef}
+            // ATTEMPT TO RENDER NEW COLUMN NAME STARTS
+            refetchCategories={refetchCategories}
+            // ATTEMPT TO RENDER NEW COLUMN NAME ENDS
           />
         </Paper>
       </Stack>

--- a/client/src/components/categories/manage/CategoryManager.tsx
+++ b/client/src/components/categories/manage/CategoryManager.tsx
@@ -13,13 +13,10 @@ import { Category } from '../../../../../shared/types';
 
 interface CategoryManagerProps {
   category: Category;
-  // ATTEMPT TO RENDER NEW COLUMN NAME STARTS
   refetchCategories: () => void;
-  // ATTEMPT TO RENDER NEW COLUMN NAME ENDS
 }
-// ATTEMPT TO RENDER NEW COLUMN NAME STARTS
+
 export const CategoryManager = ({ category, refetchCategories }: CategoryManagerProps) => {
-// ATTEMPT TO RENDER NEW COLUMN NAME ENDS
   const [isEditing, setIsEditing] = useState(false);
   const [isAdding, setIsAdding] = useState(false);
   const tableRef = useRef<{
@@ -102,9 +99,7 @@ export const CategoryManager = ({ category, refetchCategories }: CategoryManager
             category={category}
             isEditing={isEditing}
             ref={tableRef}
-            // ATTEMPT TO RENDER NEW COLUMN NAME STARTS
             refetchCategories={refetchCategories}
-            // ATTEMPT TO RENDER NEW COLUMN NAME ENDS
           />
         </Paper>
       </Stack>

--- a/client/src/components/categories/manage/ManageCategoriesSection.tsx
+++ b/client/src/components/categories/manage/ManageCategoriesSection.tsx
@@ -3,7 +3,6 @@ import { CategoryManager } from "./CategoryManager";
 import { useGetCategoriesQuery } from "../../../features/apiSlice";
 
 export const ManageCategoriesSection = () => {
-	// ATTEMPT TO RENDER NEW COLUMN NAME STARTS
 	const { data: categoriesData = [], refetch } = useGetCategoriesQuery();
 	console.log(categoriesData);
 	return (

--- a/client/src/components/categories/manage/ManageCategoriesSection.tsx
+++ b/client/src/components/categories/manage/ManageCategoriesSection.tsx
@@ -3,7 +3,8 @@ import { CategoryManager } from "./CategoryManager";
 import { useGetCategoriesQuery } from "../../../features/apiSlice";
 
 export const ManageCategoriesSection = () => {
-	const { data: categoriesData = [] } = useGetCategoriesQuery();
+	// ATTEMPT TO RENDER NEW COLUMN NAME STARTS
+	const { data: categoriesData = [], refetch } = useGetCategoriesQuery();
 	console.log(categoriesData);
 	return (
 		<Stack gap={4}>
@@ -15,7 +16,7 @@ export const ManageCategoriesSection = () => {
 							p: 2,
 						}}
 					>
-						<CategoryManager category={category} />
+						<CategoryManager category={category} refetchCategories={refetch} />
 					</Paper>
 				);
 			})}

--- a/client/src/components/categories/visualize/CategoryTable.tsx
+++ b/client/src/components/categories/visualize/CategoryTable.tsx
@@ -14,7 +14,7 @@ import {
 import { Category } from '../../../features/categoryDataSlice';
 import { useState, useEffect, forwardRef, useImperativeHandle } from 'react';
 import { Delete as DeleteIcon, Add as AddIcon } from '@mui/icons-material';
-import { useDeleteItemMutation } from '../../../features/apiSlice';
+import { useDeleteItemMutation, useAddColumnMutation } from '../../../features/apiSlice';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
 import DialogContent from '@mui/material/DialogContent';
@@ -40,6 +40,8 @@ export const CategoryTable = forwardRef(
     const [deleteItemMutation] = useDeleteItemMutation();
 
     const [openDialogs, setOpenDialogs] = useState<Record<number, boolean>>({});
+
+    const [addColumn] = useAddColumnMutation();
 
     useEffect(() => {
       if (isEditing) {
@@ -84,8 +86,21 @@ export const CategoryTable = forwardRef(
     };
 
     // ATTEMPT TO ADD FUNCTION TO HANDLE ADD COLUMN BUTTON ACTION STARTS 
-    const handleAddColumn = () => {
-      console.log('Add column clicked');
+    const handleAddColumn = async () => {
+      const newKey = prompt('Enter name for new column:');
+      if (!newKey) return;
+    
+      console.log('New column name:', newKey);
+      
+      try {
+        await addColumn({
+          categoryId: category.id,
+          columnName: newKey
+        }).unwrap();
+        console.log(`Column "${newKey}" added successfully`);
+      } catch (error) {
+        console.error('Failed to add column:', error);
+      }
     };
     // ATTEMPT TO ADD FUNCTION TO HANDLE ADD COLUMN BUTTON ACTION ENDS 
 

--- a/client/src/components/categories/visualize/CategoryTable.tsx
+++ b/client/src/components/categories/visualize/CategoryTable.tsx
@@ -24,10 +24,15 @@ import DialogTitle from '@mui/material/DialogTitle';
 interface CategoryTableProps {
   category: Category;
   isEditing: boolean;
+  // ATTEMPT TO RENDER NEW COLUMN NAME STARTS
+  refetchCategories: () => void;
+  // ATTEMPT TO RENDER NEW COLUMN NAME ENDS
 }
 
 export const CategoryTable = forwardRef(
-  ({ category, isEditing }: CategoryTableProps, ref) => {
+  // ATTEMPT TO RENDER NEW COLUMN NAME STARTS
+  ({ category, isEditing, refetchCategories }: CategoryTableProps, ref) => {
+  // ATTEMPT TO RENDER NEW COLUMN NAME ENDS
     const [page, setPage] = useState(1);
     const [formValues, setFormValues] = useState<
       Record<number, Record<string, string>>
@@ -98,6 +103,9 @@ export const CategoryTable = forwardRef(
           columnName: newKey
         }).unwrap();
         console.log(`Column "${newKey}" added successfully`);
+        // ATTEMPT TO RENDER NEW COLUMN NAME STARTS
+        refetchCategories();
+        // ATTEMPT TO RENDER NEW COLUMN NAME ENDS
       } catch (error) {
         console.error('Failed to add column:', error);
       }

--- a/client/src/components/categories/visualize/CategoryTable.tsx
+++ b/client/src/components/categories/visualize/CategoryTable.tsx
@@ -24,15 +24,11 @@ import DialogTitle from '@mui/material/DialogTitle';
 interface CategoryTableProps {
   category: Category;
   isEditing: boolean;
-  // ATTEMPT TO RENDER NEW COLUMN NAME STARTS
   refetchCategories: () => void;
-  // ATTEMPT TO RENDER NEW COLUMN NAME ENDS
 }
 
 export const CategoryTable = forwardRef(
-  // ATTEMPT TO RENDER NEW COLUMN NAME STARTS
   ({ category, isEditing, refetchCategories }: CategoryTableProps, ref) => {
-  // ATTEMPT TO RENDER NEW COLUMN NAME ENDS
     const [page, setPage] = useState(1);
     const [formValues, setFormValues] = useState<
       Record<number, Record<string, string>>
@@ -90,7 +86,6 @@ export const CategoryTable = forwardRef(
       }));
     };
 
-    // ATTEMPT TO ADD FUNCTION TO HANDLE ADD COLUMN BUTTON ACTION STARTS 
     const handleAddColumn = async () => {
       const newKey = prompt('Enter name for new column:');
       if (!newKey) return;
@@ -103,14 +98,11 @@ export const CategoryTable = forwardRef(
           columnName: newKey
         }).unwrap();
         console.log(`Column "${newKey}" added successfully`);
-        // ATTEMPT TO RENDER NEW COLUMN NAME STARTS
-        refetchCategories();
-        // ATTEMPT TO RENDER NEW COLUMN NAME ENDS
+        refetchCategories(); // rendering the new column name
       } catch (error) {
         console.error('Failed to add column:', error);
       }
     };
-    // ATTEMPT TO ADD FUNCTION TO HANDLE ADD COLUMN BUTTON ACTION ENDS 
 
     useImperativeHandle(ref, () => ({
       getFormValues: () => {
@@ -170,7 +162,6 @@ export const CategoryTable = forwardRef(
                 </TableCell>
               ))}
 
-              {/* ATTEMPT TO ADD COLUMN BUTTON START*/}
               {isEditing && (
                 <TableCell sx={{ fontSize: '0.8125rem' }}>
                   <IconButton
@@ -183,7 +174,6 @@ export const CategoryTable = forwardRef(
                   </IconButton>
                 </TableCell>
               )}
-              {/* ATTEMPT TO ADD COLUMN BUTTON ENDS */}
 
             </TableRow>
           </TableHead>

--- a/client/src/components/categories/visualize/CategoryTable.tsx
+++ b/client/src/components/categories/visualize/CategoryTable.tsx
@@ -13,7 +13,7 @@ import {
 } from '@mui/material';
 import { Category } from '../../../features/categoryDataSlice';
 import { useState, useEffect, forwardRef, useImperativeHandle } from 'react';
-import { Delete as DeleteIcon } from '@mui/icons-material';
+import { Delete as DeleteIcon, Add as AddIcon } from '@mui/icons-material';
 import { useDeleteItemMutation } from '../../../features/apiSlice';
 import Dialog from '@mui/material/Dialog';
 import DialogActions from '@mui/material/DialogActions';
@@ -83,6 +83,12 @@ export const CategoryTable = forwardRef(
       }));
     };
 
+    // ATTEMPT TO ADD FUNCTION TO HANDLE ADD COLUMN BUTTON ACTION STARTS 
+    const handleAddColumn = () => {
+      console.log('Add column clicked');
+    };
+    // ATTEMPT TO ADD FUNCTION TO HANDLE ADD COLUMN BUTTON ACTION ENDS 
+
     useImperativeHandle(ref, () => ({
       getFormValues: () => {
         const dirtyFormValues: Record<number, Record<string, string>> = {};
@@ -134,11 +140,28 @@ export const CategoryTable = forwardRef(
           <TableHead>
             <TableRow>
               <TableCell sx={{ fontSize: '0.8125rem' }}>ID</TableCell>
+              
               {Object.keys(category.itemShape).map((key) => (
                 <TableCell key={key} sx={{ fontSize: '0.8125rem' }}>
                   {key}
                 </TableCell>
               ))}
+
+              {/* ATTEMPT TO ADD COLUMN BUTTON START*/}
+              {isEditing && (
+                <TableCell sx={{ fontSize: '0.8125rem' }}>
+                  <IconButton
+                    size="small"
+                    color="primary"
+                    onClick={handleAddColumn}
+                    aria-label="Add column"
+                  >
+                    <AddIcon fontSize="small" />
+                  </IconButton>
+                </TableCell>
+              )}
+              {/* ATTEMPT TO ADD COLUMN BUTTON ENDS */}
+
             </TableRow>
           </TableHead>
           <TableBody>

--- a/client/src/components/categories/visualize/CategoryTable.tsx
+++ b/client/src/components/categories/visualize/CategoryTable.tsx
@@ -24,7 +24,7 @@ import DialogTitle from '@mui/material/DialogTitle';
 interface CategoryTableProps {
   category: Category;
   isEditing: boolean;
-  refetchCategories: () => void;
+  refetchCategories?: () => void;
 }
 
 export const CategoryTable = forwardRef(
@@ -98,7 +98,7 @@ export const CategoryTable = forwardRef(
           columnName: newKey
         }).unwrap();
         console.log(`Column "${newKey}" added successfully`);
-        refetchCategories(); // rendering the new column name
+        refetchCategories?.(); // rendering the new column name
       } catch (error) {
         console.error('Failed to add column:', error);
       }

--- a/client/src/features/apiSlice.ts
+++ b/client/src/features/apiSlice.ts
@@ -5,7 +5,11 @@ import {
   Category,
   Item,
   AddItemResponse,
-  PingResponse
+  PingResponse,
+  //ATTEMPT TO ADD ENDPOINT FOR ADDING COLUMN STARTS
+  AddColumnRequest,
+  AddColumnResponse
+  //ATTEMPT TO ADD ENDPOINT FOR ADDING COLUMN STARTS
 } from '../../../shared/types';
 import { addNotification } from './notificationSlice';
 
@@ -71,7 +75,37 @@ export const apiSlice = createApi({
         body: id
       }),
       invalidatesTags: ['Item', 'Category']
+    }),
+    //ATTEMPT TO ADD ENDPOINT FOR ADDING COLUMN STARTS
+    addColumn: builder.mutation<AddColumnResponse, AddColumnRequest>({
+      query: ({ categoryId, columnName }) => ({
+        url: `manage/categories/${categoryId}/columns`, // Update if your backend uses a different path
+        method: 'POST', // Use PATCH if that's what your backend expects
+        body: { columnName }
+      }),
+      invalidatesTags: ['Category'],
+      async onQueryStarted({ columnName }, { dispatch, queryFulfilled }) {
+        try {
+          await queryFulfilled;
+          dispatch(
+            addNotification({
+              id: crypto.randomUUID(),
+              message: `Column "${columnName}" added successfully`,
+              severity: 'info'
+            })
+          );
+        } catch (error: any) {
+          dispatch(
+            addNotification({
+              id: crypto.randomUUID(),
+              message: `Failed to add column: ${error.error.data.error}`,
+              severity: 'error'
+            })
+          );
+        }
+      }
     })
+    //ATTEMPT TO ADD ENDPOINT FOR ADDING COLUMN ENDS
   })
 });
 
@@ -80,5 +114,8 @@ export const {
   useGetCategoriesQuery,
   useAddCategoryMutation,
   useAddItemMutation,
-  useDeleteItemMutation
+  useDeleteItemMutation,
+  //ATTEMPT TO ADD ENDPOINT FOR ADDING COLUMN STARTS
+  useAddColumnMutation
+  //ATTEMPT TO ADD ENDPOINT FOR ADDING COLUMN ENDS
 } = apiSlice;

--- a/client/src/features/apiSlice.ts
+++ b/client/src/features/apiSlice.ts
@@ -76,11 +76,10 @@ export const apiSlice = createApi({
       }),
       invalidatesTags: ['Item', 'Category']
     }),
-    //ATTEMPT TO ADD ENDPOINT FOR ADDING COLUMN STARTS
     addColumn: builder.mutation<AddColumnResponse, AddColumnRequest>({
       query: ({ categoryId, columnName }) => ({
-        url: `manage/categories/${categoryId}/columns`, // Update if your backend uses a different path
-        method: 'POST', // Use PATCH if that's what your backend expects
+        url: `manage/categories/${categoryId}/columns`, 
+        method: 'POST', 
         body: { columnName }
       }),
       invalidatesTags: ['Category'],
@@ -105,7 +104,6 @@ export const apiSlice = createApi({
         }
       }
     })
-    //ATTEMPT TO ADD ENDPOINT FOR ADDING COLUMN ENDS
   })
 });
 
@@ -115,7 +113,5 @@ export const {
   useAddCategoryMutation,
   useAddItemMutation,
   useDeleteItemMutation,
-  //ATTEMPT TO ADD ENDPOINT FOR ADDING COLUMN STARTS
   useAddColumnMutation
-  //ATTEMPT TO ADD ENDPOINT FOR ADDING COLUMN ENDS
 } = apiSlice;

--- a/client/src/features/apiSlice.ts
+++ b/client/src/features/apiSlice.ts
@@ -49,11 +49,12 @@ export const apiSlice = createApi({
             })
           );
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        } catch (error: any) {
+        }  catch (error: unknown) {
+          const err = error as { error?: { data?: { error?: string } } };
           mutationLifeCycleApi.dispatch(
             addNotification({
               id: crypto.randomUUID(),
-              message: `Failed to add category: ${error.error.data.error}.`,
+              message: `Failed to add category: ${err.error?.data?.error ?? 'Unknown error'}.`,
               severity: 'error'
             })
           );
@@ -93,11 +94,12 @@ export const apiSlice = createApi({
               severity: 'info'
             })
           );
-        } catch (error: any) {
+        } catch (error: unknown) {
+          const err = error as { error?: { data?: { error?: string } } };
           dispatch(
             addNotification({
               id: crypto.randomUUID(),
-              message: `Failed to add column: ${error.error.data.error}`,
+              message: `Failed to add column: ${err.error?.data?.error ?? 'Unknown error'}`,
               severity: 'error'
             })
           );

--- a/server/src/routers/categoryRouter.ts
+++ b/server/src/routers/categoryRouter.ts
@@ -64,27 +64,44 @@ router.put('/:categoryId', (req, res) => {
     });
 });
 
-// ATTEMPT TO ADD DUMMY ROUTE FOR ADDING COLUMN STARTS
-router.post('/:categoryId/columns', (req, res) => {
+// ATTEMPT TO ADD DUMMY ROUTE FOR ADDING AND RENDERING COLUMN STARTS
+router.post('/:categoryId/columns', async (req, res) => {
   const { categoryId } = req.params;
   const { columnName } = req.body;
 
   console.log(`Received request to add column "${columnName}" to category ${categoryId}`);
 
-  res.status(200).json({
-    success: true,
-    updatedCategory: {
-      id: Number(categoryId),
-      name: 'Stubbed Category',
-      itemShape: {
-        name: 'string',
-        existingColumn: 'string',
-        [columnName]: 'string' 
-      },
-      items: []
+  try {
+    // 1. Fetch existing categories
+    const categories = await getCategories();
+    const category = categories.find((cat) => cat.id === Number(categoryId));
+
+    if (!category) {
+      return res.status(404).json({ error: 'Category not found' });
     }
-  });
+
+    // 2. Add new column to itemShape
+    const updatedShape = {
+      ...category.itemShape,
+      [columnName]: 'string'
+    };
+
+    // 3. Persist it using your existing logic
+    await AlterCategory(categoryId, updatedShape);
+
+    // 4. Return the updated category
+    res.status(200).json({
+      success: true,
+      updatedCategory: {
+        ...category,
+        itemShape: updatedShape
+      }
+    });
+  } catch (error) {
+    console.error('Error adding column:', error);
+    res.status(500).json({ error: 'Failed to add column' });
+  }
 });
-// ATTEMPT TO ADD DUMMY ROUTE FOR ADDING COLUMN ENDS
+// ATTEMPT TO ADD DUMMY ROUTE FOR ADDING AND RENDERING COLUMN ENDS
 
 export default router;

--- a/server/src/routers/categoryRouter.ts
+++ b/server/src/routers/categoryRouter.ts
@@ -64,4 +64,27 @@ router.put('/:categoryId', (req, res) => {
     });
 });
 
+// ATTEMPT TO ADD DUMMY ROUTE FOR ADDING COLUMN STARTS
+router.post('/:categoryId/columns', (req, res) => {
+  const { categoryId } = req.params;
+  const { columnName } = req.body;
+
+  console.log(`Received request to add column "${columnName}" to category ${categoryId}`);
+
+  res.status(200).json({
+    success: true,
+    updatedCategory: {
+      id: Number(categoryId),
+      name: 'Stubbed Category',
+      itemShape: {
+        name: 'string',
+        existingColumn: 'string',
+        [columnName]: 'string' 
+      },
+      items: []
+    }
+  });
+});
+// ATTEMPT TO ADD DUMMY ROUTE FOR ADDING COLUMN ENDS
+
 export default router;

--- a/server/src/routers/categoryRouter.ts
+++ b/server/src/routers/categoryRouter.ts
@@ -64,7 +64,7 @@ router.put('/:categoryId', (req, res) => {
     });
 });
 
-// ATTEMPT TO ADD DUMMY ROUTE FOR ADDING AND RENDERING COLUMN STARTS
+// DUMMY ROUTE FOR ADDING AND RENDERING COLUMN JUST TO VERIFY FUNCTIONALITY IN FRONTEND
 router.post('/:categoryId/columns', async (req, res) => {
   const { categoryId } = req.params;
   const { columnName } = req.body;
@@ -72,7 +72,6 @@ router.post('/:categoryId/columns', async (req, res) => {
   console.log(`Received request to add column "${columnName}" to category ${categoryId}`);
 
   try {
-    // 1. Fetch existing categories
     const categories = await getCategories();
     const category = categories.find((cat) => cat.id === Number(categoryId));
 
@@ -80,16 +79,13 @@ router.post('/:categoryId/columns', async (req, res) => {
       return res.status(404).json({ error: 'Category not found' });
     }
 
-    // 2. Add new column to itemShape
     const updatedShape = {
       ...category.itemShape,
       [columnName]: 'string'
     };
 
-    // 3. Persist it using your existing logic
     await AlterCategory(categoryId, updatedShape);
 
-    // 4. Return the updated category
     res.status(200).json({
       success: true,
       updatedCategory: {
@@ -102,6 +98,5 @@ router.post('/:categoryId/columns', async (req, res) => {
     res.status(500).json({ error: 'Failed to add column' });
   }
 });
-// ATTEMPT TO ADD DUMMY ROUTE FOR ADDING AND RENDERING COLUMN ENDS
 
 export default router;

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -31,3 +31,13 @@ export interface Item {
   id: number;
   data: Record<string, string>;
 }
+
+export interface AddColumnRequest {
+  categoryId: number;
+  columnName: string;
+}
+
+export interface AddColumnResponse {
+  success: boolean;
+  updatedCategory: Category;
+}


### PR DESCRIPTION
This PR is realted to task [Frontend: + button for new columns right hand corner of table](https://github.com/orgs/ohtu-megasense/projects/2/views/2?pane=issue&itemId=100654138&issue=ohtu-megasense%7Cerp%7C165). Tested manually that:

- After pressing edit icon of table a + icon appears next to last column
- After pressing + icon a dialog box appears where one can insert the new column name
- After confirming the new column name is rendered into the table
- Afterwards one can add new itesms with the new column included as well

Dummy router created to backend in order to check that it works as intended.