### PR TITLE
Sending html file to client when it requests unknown page

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -8,7 +8,8 @@ import path from 'path';
 
 const app = express();
 
-app.use(express.static(path.join(__dirname, '../dist')));
+const distPath = path.join(__dirname, '../dist');
+app.use(express.static(distPath));
 
 app.use(cors());
 app.use(express.json());
@@ -27,7 +28,13 @@ if (env === 'test' || env === 'development') {
 }
 
 app.get('/*', (req, res) => {
-  res.status(404).json({ message: 'Unknown endpoint!' });
+  if (req.originalUrl.startsWith('/api')) {
+    res.status(404).json({ message: 'Unknown endpoint!' });
+    return;
+  }
+
+  const filePath = `${distPath}/index.html`;
+  res.sendFile(filePath);
 });
 
 export default app;


### PR DESCRIPTION
- NOTE: This only affects the built/prod version of the app!

- Previously if user sent request to any invalid endpoint the response was always 'Unknown endpoint'.

- Now instead if the request is not to /api endpoint we handle it as user trying to navigate in browser through the url.

- Solution is to send the html file (frontend app) back to the user. React router should then read the url and navigate to correct frontend route. Memory of the frontend app is resets because it gets reloaded.