### PR TITLE
Feat/decorator filters

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -3,6 +3,7 @@ import cors from 'cors';
 import pingRouter from './routers/pingRouter';
 import categoryRouter from './routers/categoryRouter';
 import itemRouter from './routers/itemRouter';
+import viewRouter from './routers/viewRouter'
 import { requestLogger } from './utils/middleware';
 import path from 'path';
 
@@ -17,6 +18,7 @@ app.use(requestLogger);
 app.use('/api/ping', pingRouter);
 app.use('/api/manage/categories', categoryRouter);
 app.use('/api/items', itemRouter);
+app.use('/api/views', viewRouter)
 
 const env = process.env.NODE_ENV;
 

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -3,7 +3,7 @@ import cors from 'cors';
 import pingRouter from './routers/pingRouter';
 import categoryRouter from './routers/categoryRouter';
 import itemRouter from './routers/itemRouter';
-import viewRouter from './routers/viewRouter'
+import viewRouter from './routers/viewRouter';
 import { requestLogger } from './utils/middleware';
 import path from 'path';
 
@@ -18,7 +18,7 @@ app.use(requestLogger);
 app.use('/api/ping', pingRouter);
 app.use('/api/manage/categories', categoryRouter);
 app.use('/api/items', itemRouter);
-app.use('/api/views', viewRouter)
+app.use('/api/views', viewRouter);
 
 const env = process.env.NODE_ENV;
 

--- a/server/src/database/database.ts
+++ b/server/src/database/database.ts
@@ -109,6 +109,7 @@ export const resetDatabase = async () => {
 		text: `
       DELETE FROM items;
       DELETE FROM categories;
+      DELETE FROM views;
     `,
 	};
 

--- a/server/src/database/database.ts
+++ b/server/src/database/database.ts
@@ -1,71 +1,71 @@
-import { Client, Pool } from "pg";
-import { database_URL } from "../config";
-import fs from "fs";
-import path from "path";
-import logger from "../utils/logger";
+import { Client, Pool } from 'pg';
+import { database_URL } from '../config';
+import fs from 'fs';
+import path from 'path';
+import logger from '../utils/logger';
 
 const getCaPath = (): string | undefined => {
-	const env = process.env.NODE_ENV;
+  const env = process.env.NODE_ENV;
 
-	if (env === "production") {
-		return process.env.CA_PATH || path.join(__dirname, "../../ca.pem");
-	}
+  if (env === 'production') {
+    return process.env.CA_PATH || path.join(__dirname, '../../ca.pem');
+  }
 
-	return undefined;
+  return undefined;
 };
 
 const getDatabaseClient = (): Client => {
-	if (process.env.NODE_ENV === "production") {
-		const caPath = getCaPath();
-		logger.info(
-			`Database certificate authority file for pg.Client is using path: ${caPath}.`,
-		);
+  if (process.env.NODE_ENV === 'production') {
+    const caPath = getCaPath();
+    logger.info(
+      `Database certificate authority file for pg.Client is using path: ${caPath}.`
+    );
 
-		if (!caPath) {
-			throw new Error(
-				"Certificate authority path for pg.Client is undefined. Is the process node env in production mode?",
-			);
-		}
+    if (!caPath) {
+      throw new Error(
+        'Certificate authority path for pg.Client is undefined. Is the process node env in production mode?'
+      );
+    }
 
-		return new Client({
-			connectionString: database_URL,
-			ssl: {
-				rejectUnauthorized: true,
-				ca: fs.readFileSync(caPath).toString(),
-			},
-		});
-	}
+    return new Client({
+      connectionString: database_URL,
+      ssl: {
+        rejectUnauthorized: true,
+        ca: fs.readFileSync(caPath).toString()
+      }
+    });
+  }
 
-	return new Client({
-		connectionString: database_URL,
-	});
+  return new Client({
+    connectionString: database_URL
+  });
 };
 
 const getDatabasePool = (): Pool => {
-	if (process.env.NODE_ENV === "production") {
-		const caPath = getCaPath();
-		logger.info(
-			`Database certificate authority file for pg.Pool is using path: ${caPath}.`,
-		);
+  if (process.env.NODE_ENV === 'production') {
+    const caPath = getCaPath();
+    logger.info(
+      `Database certificate authority file for pg.Pool is using path: ${caPath}.`
+    );
 
-		if (!caPath) {
-			throw new Error(
-				"Certificate authority path for pg.Pool is undefined. Is the process node env in production mode?",
-			);
-		}
+    if (!caPath) {
+      throw new Error(
+        'Certificate authority path for pg.Pool is undefined. Is the process node env in production mode?'
+      );
+    }
 
-		return new Pool({
-			connectionString: database_URL,
-			ssl: {
-				rejectUnauthorized: true,
-				ca: fs.readFileSync(caPath).toString(),
-			},
-		});
-	}
+    return new Pool({
+      connectionString: database_URL,
+      ssl: {
+        rejectUnauthorized: true,
+        ca: fs.readFileSync(caPath).toString()
+      }
+    });
+  }
 
-	return new Pool({
-		connectionString: database_URL,
-	});
+  return new Pool({
+    connectionString: database_URL
+  });
 };
 
 // Client is used for checking if
@@ -76,66 +76,66 @@ const client = getDatabaseClient();
 export const pool = getDatabasePool();
 
 export const testDatabaseConnection = async (): Promise<{
-	isConnectionSuccessful: boolean;
+  isConnectionSuccessful: boolean;
 }> => {
-	try {
-		await client.connect();
+  try {
+    await client.connect();
 
-		logger.info("Data base connection successful.");
+    logger.info('Data base connection successful.');
 
-		await client.end();
+    await client.end();
 
-		return {
-			isConnectionSuccessful: true,
-		};
-	} catch (error) {
-		let logMessage = "";
+    return {
+      isConnectionSuccessful: true
+    };
+  } catch (error) {
+    let logMessage = '';
 
-		if (error instanceof Error) {
-			logMessage += error.message;
-		}
+    if (error instanceof Error) {
+      logMessage += error.message;
+    }
 
-		await client.end();
-		logger.error(`Database connection failed. Error message: ${logMessage}`);
+    await client.end();
+    logger.error(`Database connection failed. Error message: ${logMessage}`);
 
-		return {
-			isConnectionSuccessful: false,
-		};
-	}
+    return {
+      isConnectionSuccessful: false
+    };
+  }
 };
 
 export const resetDatabase = async () => {
-	const query = {
-		text: `
+  const query = {
+    text: `
       DELETE FROM items;
       DELETE FROM categories;
       DELETE FROM views;
-    `,
-	};
+    `
+  };
 
-	await pool.query(query);
+  await pool.query(query);
 };
 
 const loadSchema = async () => {
-	try {
-		await client.connect();
-		console.log("Connected to the database");
+  try {
+    await client.connect();
+    console.log('Connected to the database');
 
-		const schemaPath = path.join(__dirname, "schema.sql");
-		const SQLschema = fs.readFileSync(schemaPath, "utf-8");
+    const schemaPath = path.join(__dirname, 'schema.sql');
+    const SQLschema = fs.readFileSync(schemaPath, 'utf-8');
 
-		await client.query(SQLschema);
-		console.log("Schema loaded successfully");
+    await client.query(SQLschema);
+    console.log('Schema loaded successfully');
 
-		await client.query(
-			"INSERT INTO modules(module_name) VALUES ('crm'),('inventory');",
-		);
-	} finally {
-		await client.end();
-		console.log("Disconnected from the database");
-	}
+    await client.query(
+      "INSERT INTO modules(module_name) VALUES ('crm'),('inventory');"
+    );
+  } finally {
+    await client.end();
+    console.log('Disconnected from the database');
+  }
 };
 
 if (require.main == module) {
-	loadSchema();
+  loadSchema();
 }

--- a/server/src/database/database_handler.ts
+++ b/server/src/database/database_handler.ts
@@ -125,25 +125,6 @@ export const renameCategory = async (
   }
 };
 
-export class ItemFilterService {
-  async getFilteredItems(filter?: Filter): Promise<any[]> {
-    try {
-      const query = 'SELECT * FROM items;';
-      const result = await pool.query(query);
-      let items = result.rows;
-
-      if (filter) {
-        items = filter.apply(items);
-        logger.info(`Used filter: ${filter.getDescription()}`);
-      }
-
-      return items;
-    } catch (error) {
-      logger.error('Error filtering items:', error);
-      throw error;
-    }
-  }
-}
 
 export const getCategories = async (
   moduleName: string

--- a/server/src/database/database_handler.ts
+++ b/server/src/database/database_handler.ts
@@ -124,8 +124,13 @@ export const renameCategory = async (
 	}
 };
 
-// export const getCategories = async (module): etc.
-// jos halutaan hakea moduulin kategoriat
+export const getAllItems = async () => {
+  const query = "SELECT * FROM items;"
+  const result = await pool.query(query)
+
+  return result
+}
+
 export const getCategories = async (
 	moduleName: string,
 ): Promise<Category[]> => {

--- a/server/src/database/database_handler.ts
+++ b/server/src/database/database_handler.ts
@@ -25,14 +25,14 @@ export const getModuleIdByName = async (
   try {
     const sql_text: string = 'SELECT id FROM modules WHERE module_name=%L;';
 
-    console.log('[getModuleIdByName] printing module_name:', module_name);
+    logger.info('[getModuleIdByName] printing module_name:', module_name);
 
     const query = format(sql_text, module_name);
-    console.log('[getModuleIdByName] printing SQL text:', query);
+    logger.info('[getModuleIdByName] printing SQL text:', query);
     const result = await pool.query(query);
 
-    //console.log("printing result:", result);
-    console.log('[getModuleIdByName] printing result.rows[0]', result.rows[0]);
+    //logger.info("printing result:", result);
+    logger.info('[getModuleIdByName] printing result.rows[0]', result.rows[0]);
 
     return result.rows.length > 0 ? result.rows[0].id : null;
   } catch (error) {
@@ -53,10 +53,10 @@ export const addCategory = async (
   itemShape: Record<string, string>;
 }> => {
   const moduleName = params.module.toLowerCase();
-  console.log(params);
-  console.log('[addCategory] printing module name: ', moduleName);
+  logger.info(params);
+  logger.info('[addCategory] printing module name: ', moduleName);
   const module_id = await getModuleIdByName(moduleName);
-  console.log('[addCategory] module ID: ', module_id);
+  logger.info('[addCategory] module ID: ', module_id);
 
   const query = format(
     `
@@ -129,7 +129,7 @@ export const getCategories = async (
   moduleName: string
 ): Promise<Category[]> => {
   const module_id = await getModuleIdByName(moduleName);
-  console.log('[getCategories] module ID:', module_id);
+  logger.info('[getCategories] module ID:', module_id);
   const query = format(
     `
       SELECT 
@@ -196,7 +196,7 @@ export async function deleteCategory(category_id: string) {
 
 async function getCategoryById(category_id: string) {
   try {
-    console.log('[getCategoryById] category_id: ', category_id);
+    logger.info('[getCategoryById] category_id: ', category_id);
     const sql_text: string = 'SELECT * FROM categories WHERE id=%L';
 
     const query = format(sql_text, category_id);
@@ -220,8 +220,8 @@ async function validateAddItem(
   try {
     const category = await getCategoryById(category_id);
     const columns = category['item_shape'];
-    console.log('[validateAddItem] item_shape: ', columns);
-    console.log('[validateAddItem] item_data: ', item_data);
+    logger.info('[validateAddItem] item_shape: ', columns);
+    logger.info('[validateAddItem] item_data: ', item_data);
 
     for (const key in columns) {
       if (key in item_data) {
@@ -229,17 +229,17 @@ async function validateAddItem(
           // Convert the value to a number first
           const realType = typeof item_data[key];
           if (realType !== 'number') {
-            console.log('[validateAddItem] invalid value for Integer');
+            logger.info('[validateAddItem] invalid value for Integer');
             return false;
           }
         } else if (columns[key] === 'FLOAT') {
           const realType = typeof item_data[key];
           if (realType !== 'number') {
-            console.log('[validateAddItem] invalid value for Float');
+            logger.info('[validateAddItem] invalid value for Float');
             return false;
           }
         }
-        console.log(
+        logger.info(
           `[validateAddItem] ${key}: ${columns[key]} - ${item_data[key]}`
         );
       }
@@ -274,7 +274,7 @@ export async function AddItem(
         `[addItem] category ${category_id} with item data ${item_data}" added`
       );
     } else {
-      console.log('[addItem] invalid input');
+      logger.info('[addItem] invalid input');
     }
   } catch (error) {
     logger.error('[addItem] Error adding item:', error);

--- a/server/src/database/database_handler.ts
+++ b/server/src/database/database_handler.ts
@@ -1,18 +1,18 @@
 import format from 'pg-format';
 import logger from '../utils/logger';
 import { pool } from './database';
-import { Category } from '../../../shared/types';
+import { AddCategoryRequest, Category } from '../../../shared/types';
 
 // TODO: In getCategories sql query if a category has
 // no items the items array will contain a single object
 // like { id: null, data: null }. Ideally an empty
 // array would be returned.
 
-interface AddCategoryParams {
-  name: string;
-  module: string;
-  itemShape: Record<string, string>;
-}
+// interface AddCategoryParams {
+//   name: string;
+//   module: string;
+//   itemShape: Record<string, string>;
+// }
 
 // interface renameCategoryParams {
 //   id: number;
@@ -45,7 +45,7 @@ export const getModuleIdByName = async (
 };
 
 export const addCategory = async (
-  params: AddCategoryParams
+  params: AddCategoryRequest
 ): Promise<{
   id: number;
   module_id: number;

--- a/server/src/database/database_handler.ts
+++ b/server/src/database/database_handler.ts
@@ -1,7 +1,8 @@
-import format from "pg-format";
-import logger from "../utils/logger";
-import { pool } from "./database";
-import { Category } from "../../../shared/types";
+import format from 'pg-format';
+import logger from '../utils/logger';
+import { pool } from './database';
+import { Category } from '../../../shared/types';
+import { Filter } from '../filters/filters';
 
 // TODO: In getCategories sql query if a category has
 // no items the items array will contain a single object
@@ -9,9 +10,9 @@ import { Category } from "../../../shared/types";
 // array would be returned.
 
 interface AddCategoryParams {
-	name: string;
-	module: string;
-	itemShape: Record<string, string>;
+  name: string;
+  module: string;
+  itemShape: Record<string, string>;
 }
 
 // interface renameCategoryParams {
@@ -20,46 +21,46 @@ interface AddCategoryParams {
 // }
 
 export const getModuleIdByName = async (
-	module_name: string,
+  module_name: string
 ): Promise<string | null> => {
-	try {
-		const sql_text: string = "SELECT id FROM modules WHERE module_name=%L;";
+  try {
+    const sql_text: string = 'SELECT id FROM modules WHERE module_name=%L;';
 
-		console.log("[getModuleIdByName] printing module_name:", module_name);
+    console.log('[getModuleIdByName] printing module_name:', module_name);
 
-		const query = format(sql_text, module_name);
-		console.log("[getModuleIdByName] printing SQL text:", query);
-		const result = await pool.query(query);
+    const query = format(sql_text, module_name);
+    console.log('[getModuleIdByName] printing SQL text:', query);
+    const result = await pool.query(query);
 
-		//console.log("printing result:", result);
-		console.log("[getModuleIdByName] printing result.rows[0]", result.rows[0]);
+    //console.log("printing result:", result);
+    console.log('[getModuleIdByName] printing result.rows[0]', result.rows[0]);
 
-		return result.rows.length > 0 ? result.rows[0].id : null;
-	} catch (error) {
-		logger.error(
-			"[getModuleIdByName] Error finding the module by name:",
-			error,
-		);
-		throw error;
-	}
+    return result.rows.length > 0 ? result.rows[0].id : null;
+  } catch (error) {
+    logger.error(
+      '[getModuleIdByName] Error finding the module by name:',
+      error
+    );
+    throw error;
+  }
 };
 
 export const addCategory = async (
-	params: AddCategoryParams,
+  params: AddCategoryParams
 ): Promise<{
-	id: number;
-	module_id: number;
-	name: string;
-	itemShape: Record<string, string>;
+  id: number;
+  module_id: number;
+  name: string;
+  itemShape: Record<string, string>;
 }> => {
-	const moduleName = params.module.toLowerCase();
-	console.log(params);
-	console.log("[addCategory] printing module name: ", moduleName);
-	const module_id = await getModuleIdByName(moduleName);
-	console.log("[addCategory] module ID: ", module_id);
+  const moduleName = params.module.toLowerCase();
+  console.log(params);
+  console.log('[addCategory] printing module name: ', moduleName);
+  const module_id = await getModuleIdByName(moduleName);
+  console.log('[addCategory] module ID: ', module_id);
 
-	const query = format(
-		`
+  const query = format(
+    `
 			INSERT INTO categories 
       (
         module_id,
@@ -73,71 +74,84 @@ export const addCategory = async (
 				category_name,
 				item_shape;
       `,
-		module_id,
-		params.name,
-		params.itemShape,
-	);
+    module_id,
+    params.name,
+    params.itemShape
+  );
 
-	const result = await pool.query<{
-		id: number;
-		module_id: number;
-		category_name: string;
-		item_shape: Record<string, string>;
-	}>(query);
+  const result = await pool.query<{
+    id: number;
+    module_id: number;
+    category_name: string;
+    item_shape: Record<string, string>;
+  }>(query);
 
-	const row = result.rows[0];
+  const row = result.rows[0];
 
-	return {
-		id: row.id,
-		module_id: row.module_id,
-		name: row.category_name,
-		// module: row.module_name tms
-		itemShape: row.item_shape,
-	};
+  return {
+    id: row.id,
+    module_id: row.module_id,
+    name: row.category_name,
+    // module: row.module_name tms
+    itemShape: row.item_shape
+  };
 };
 
 export const renameCategory = async (
-	categoryName: string,
-	categoryId: number,
+  categoryName: string,
+  categoryId: number
 ): Promise<{ name: string }> => {
-	try {
-		const query = {
-			text: `
+  try {
+    const query = {
+      text: `
       UPDATE categories SET category_name = $1 WHERE id = $2 RETURNING category_name;
       `,
-			values: [categoryName, categoryId],
-		};
+      values: [categoryName, categoryId]
+    };
 
-		const result = await pool.query(query);
-		const row = result.rows[0];
+    const result = await pool.query(query);
+    const row = result.rows[0];
 
-		if (!row) {
-			throw new Error(
-				`[renameCategory] Category with ID ${categoryId} not found`,
-			);
-		}
+    if (!row) {
+      throw new Error(
+        `[renameCategory] Category with ID ${categoryId} not found`
+      );
+    }
 
-		return { name: row.category_name };
-	} catch (error) {
-		logger.error("[renameCategory] Error updating category name", error);
-		throw error;
-	}
+    return { name: row.category_name };
+  } catch (error) {
+    logger.error('[renameCategory] Error updating category name', error);
+    throw error;
+  }
 };
 
-export const getAllItems = async () => {
-  const query = "SELECT * FROM items;"
-  const result = await pool.query(query)
+export class ItemFilterService {
+  async getFilteredItems(filter?: Filter): Promise<any[]> {
+    try {
+      const query = 'SELECT * FROM items;';
+      const result = await pool.query(query);
+      let items = result.rows;
 
-  return result
+      if (filter) {
+        items = filter.apply(items);
+        logger.info(`Used filter: ${filter.getDescription()}`);
+      }
+
+      return items;
+    } catch (error) {
+      logger.error('Error filtering items:', error);
+      throw error;
+    }
+  }
 }
 
 export const getCategories = async (
-	moduleName: string,
+  moduleName: string
 ): Promise<Category[]> => {
-	const module_id = await getModuleIdByName(moduleName);
-	console.log("[getCategories] module ID:", module_id);
-	const query = format(
-		`
+  const module_id = await getModuleIdByName(moduleName);
+  console.log('[getCategories] module ID:', module_id);
+  const query = format(
+    `
       SELECT 
         categories.id, 
         category_name, 
@@ -154,238 +168,238 @@ export const getCategories = async (
       GROUP BY category_name, categories.id
       ORDER BY categories.id;
     `,
-		module_id,
-	);
+    module_id
+  );
 
-	const result = await pool.query(query);
+  const result = await pool.query(query);
 
-	// NOTE: The filtering is done to items because
-	// the query can return items array with an object
-	// like { id: null, data: null }
+  // NOTE: The filtering is done to items because
+  // the query can return items array with an object
+  // like { id: null, data: null }
 
-	const categories: Category[] = result.rows.map((row) => {
-		return {
-			id: row.id,
-			name: row.category_name,
-			itemShape: row.item_shape,
-			items: row.items.filter((item: { id: number | null }) => item.id),
-		};
-	});
+  const categories: Category[] = result.rows.map((row) => {
+    return {
+      id: row.id,
+      name: row.category_name,
+      itemShape: row.item_shape,
+      items: row.items.filter((item: { id: number | null }) => item.id)
+    };
+  });
 
-	return categories;
+  return categories;
 };
 
 export async function deleteCategory(category_id: string) {
-	try {
-		const query = {
-			text: `
+  try {
+    const query = {
+      text: `
       DELETE FROM categories WHERE id = $1 RETURNING category_name
       `,
-			values: [category_id],
-		};
+      values: [category_id]
+    };
 
-		const result = await pool.query(query);
-		const row = result.rows[0];
+    const result = await pool.query(query);
+    const row = result.rows[0];
 
-		if (!row) {
-			throw new Error(
-				`[deleteCategory] Category with ID ${category_id} not found`,
-			);
-		}
+    if (!row) {
+      throw new Error(
+        `[deleteCategory] Category with ID ${category_id} not found`
+      );
+    }
 
-		return row;
-	} catch (error) {
-		logger.error("[deleteCategory] Error deleting category", error);
-		throw error;
-	}
+    return row;
+  } catch (error) {
+    logger.error('[deleteCategory] Error deleting category', error);
+    throw error;
+  }
 }
 
 async function getCategoryById(category_id: string) {
-	try {
-		console.log("[getCategoryById] category_id: ", category_id);
-		const sql_text: string = "SELECT * FROM categories WHERE id=%L";
+  try {
+    console.log('[getCategoryById] category_id: ', category_id);
+    const sql_text: string = 'SELECT * FROM categories WHERE id=%L';
 
-		const query = format(sql_text, category_id);
-		logger.info("[getCategoryById] SQL text: ", query);
+    const query = format(sql_text, category_id);
+    logger.info('[getCategoryById] SQL text: ', query);
 
-		const result = await pool.query(query);
+    const result = await pool.query(query);
 
-		// for later: add some other return if not found
-		return result.rows[0];
-	} catch (error) {
-		logger.error("[getCategoryById] Error finding category by ID:", error);
-	} finally {
-		logger.info("[getCategoryById] Disconnected from the database");
-	}
+    // for later: add some other return if not found
+    return result.rows[0];
+  } catch (error) {
+    logger.error('[getCategoryById] Error finding category by ID:', error);
+  } finally {
+    logger.info('[getCategoryById] Disconnected from the database');
+  }
 }
 
 async function validateAddItem(
-	category_id: string,
-	item_data: { [key: string]: string },
+  category_id: string,
+  item_data: { [key: string]: string }
 ) {
-	try {
-		const category = await getCategoryById(category_id);
-		const columns = category["item_shape"];
-		console.log("[validateAddItem] item_shape: ", columns);
-		console.log("[validateAddItem] item_data: ", item_data);
+  try {
+    const category = await getCategoryById(category_id);
+    const columns = category['item_shape'];
+    console.log('[validateAddItem] item_shape: ', columns);
+    console.log('[validateAddItem] item_data: ', item_data);
 
-		for (const key in columns) {
-			if (key in item_data) {
-				if (columns[key] === "INTEGER") {
-					// Convert the value to a number first
-					const realType = typeof item_data[key];
-					if (realType !== "number") {
-						console.log("[validateAddItem] invalid value for Integer");
-						return false;
-					}
-				} else if (columns[key] === "FLOAT") {
-					const realType = typeof item_data[key];
-					if (realType !== "number") {
-						console.log("[validateAddItem] invalid value for Float");
-						return false;
-					}
-				}
-				console.log(
-					`[validateAddItem] ${key}: ${columns[key]} - ${item_data[key]}`,
-				);
-			}
-		}
+    for (const key in columns) {
+      if (key in item_data) {
+        if (columns[key] === 'INTEGER') {
+          // Convert the value to a number first
+          const realType = typeof item_data[key];
+          if (realType !== 'number') {
+            console.log('[validateAddItem] invalid value for Integer');
+            return false;
+          }
+        } else if (columns[key] === 'FLOAT') {
+          const realType = typeof item_data[key];
+          if (realType !== 'number') {
+            console.log('[validateAddItem] invalid value for Float');
+            return false;
+          }
+        }
+        console.log(
+          `[validateAddItem] ${key}: ${columns[key]} - ${item_data[key]}`
+        );
+      }
+    }
 
-		return true;
-	} catch (error) {
-		logger.error("[validateAddItem] Error adding item:", error);
-	} finally {
-		logger.info("[validateAddItem] Disconnected from the database");
-	}
+    return true;
+  } catch (error) {
+    logger.error('[validateAddItem] Error adding item:', error);
+  } finally {
+    logger.info('[validateAddItem] Disconnected from the database');
+  }
 }
 
 export async function AddItem(
-	category_id: string,
-	item_data: { [key: string]: string },
+  category_id: string,
+  item_data: { [key: string]: string }
 ) {
-	try {
-		const isValid = await validateAddItem(category_id, item_data);
-		if (isValid) {
-			const sql_text: string =
-				"INSERT INTO items (category_id, item_data) VALUES (%L, %L)";
+  try {
+    const isValid = await validateAddItem(category_id, item_data);
+    if (isValid) {
+      const sql_text: string =
+        'INSERT INTO items (category_id, item_data) VALUES (%L, %L)';
 
-			logger.info(sql_text);
-			logger.info(category_id);
-			logger.info(item_data);
+      logger.info(sql_text);
+      logger.info(category_id);
+      logger.info(item_data);
 
-			const query = format(sql_text, category_id, item_data);
-			await pool.query(query);
+      const query = format(sql_text, category_id, item_data);
+      await pool.query(query);
 
-			logger.info(
-				`[addItem] category ${category_id} with item data ${item_data}" added`,
-			);
-		} else {
-			console.log("[addItem] invalid input");
-		}
-	} catch (error) {
-		logger.error("[addItem] Error adding item:", error);
-	} finally {
-		logger.info("[addItem] Disconnected from the database");
-	}
+      logger.info(
+        `[addItem] category ${category_id} with item data ${item_data}" added`
+      );
+    } else {
+      console.log('[addItem] invalid input');
+    }
+  } catch (error) {
+    logger.error('[addItem] Error adding item:', error);
+  } finally {
+    logger.info('[addItem] Disconnected from the database');
+  }
 }
 
 export async function UpdateItem(
-	item_id: string,
-	item_data: Record<string, string>,
+  item_id: string,
+  item_data: Record<string, string>
 ) {
-	try {
-		const sql_text: string = "UPDATE items SET item_data = (%L) WHERE id=%L";
+  try {
+    const sql_text: string = 'UPDATE items SET item_data = (%L) WHERE id=%L';
 
-		logger.info("[updateItem] SQL text: ", sql_text);
-		logger.info("[updateItem] item_id: ", item_id);
-		logger.info("[updateItem] item_data: ", item_data);
+    logger.info('[updateItem] SQL text: ', sql_text);
+    logger.info('[updateItem] item_id: ', item_id);
+    logger.info('[updateItem] item_data: ', item_data);
 
-		const query = format(sql_text, item_data, item_id);
-		await pool.query(query);
+    const query = format(sql_text, item_data, item_id);
+    await pool.query(query);
 
-		logger.info(
-			`[updateItem] Updated item with ID ${item_id} with data ${item_data}"`,
-		);
-	} catch (error) {
-		logger.error("[updateItem] Error updating item:", error);
-	} finally {
-		logger.info("[updateItem] Disconnected from the database");
-	}
+    logger.info(
+      `[updateItem] Updated item with ID ${item_id} with data ${item_data}"`
+    );
+  } catch (error) {
+    logger.error('[updateItem] Error updating item:', error);
+  } finally {
+    logger.info('[updateItem] Disconnected from the database');
+  }
 }
 
 export async function DeleteItem(item_id: string) {
-	try {
-		const sql_text: string = "DELETE FROM items WHERE id=%L;";
+  try {
+    const sql_text: string = 'DELETE FROM items WHERE id=%L;';
 
-		logger.info(sql_text);
-		logger.info(item_id);
+    logger.info(sql_text);
+    logger.info(item_id);
 
-		const query = format(sql_text, item_id);
-		const result = await pool.query(query);
+    const query = format(sql_text, item_id);
+    const result = await pool.query(query);
 
-		logger.info(`[deleteItem] item with item_id "${item_id}" deleted`);
-		return {
-			success: true,
-			rowsDeleted: result.rowCount,
-		};
-	} catch (error) {
-		logger.error("[deleteItem] Error deleting item:", error);
-		return {
-			success: false,
-			rowsDeleted: 0,
-		};
-	}
+    logger.info(`[deleteItem] item with item_id "${item_id}" deleted`);
+    return {
+      success: true,
+      rowsDeleted: result.rowCount
+    };
+  } catch (error) {
+    logger.error('[deleteItem] Error deleting item:', error);
+    return {
+      success: false,
+      rowsDeleted: 0
+    };
+  }
 }
 
 export async function CheckItemIdFound(item_id: string): Promise<boolean> {
-	try {
-		const sql_text: string = "SELECT * FROM items WHERE id=%L;";
+  try {
+    const sql_text: string = 'SELECT * FROM items WHERE id=%L;';
 
-		logger.info(sql_text);
-		logger.info("[checkItemIdFound] printing item id:", item_id);
+    logger.info(sql_text);
+    logger.info('[checkItemIdFound] printing item id:', item_id);
 
-		const query = format(sql_text, item_id);
-		const result = await pool.query(query);
+    const query = format(sql_text, item_id);
+    const result = await pool.query(query);
 
-		logger.info(result.rows.length);
-		if (result.rows.length == 1) {
-			return true;
-		} else {
-			return false;
-		}
-	} catch (error) {
-		logger.error("[checkItemIdFound] Error finding the item by ID:", error);
-		return false;
-	}
+    logger.info(result.rows.length);
+    if (result.rows.length == 1) {
+      return true;
+    } else {
+      return false;
+    }
+  } catch (error) {
+    logger.error('[checkItemIdFound] Error finding the item by ID:', error);
+    return false;
+  }
 }
 
 export const testLogCategories = async () => {
-	const sqlText = `SELECT id, category_name, item_shape FROM categories;`;
-	const result = await pool.query(sqlText);
-	logger.info("Categories from database", result.rows);
+  const sqlText = `SELECT id, category_name, item_shape FROM categories;`;
+  const result = await pool.query(sqlText);
+  logger.info('Categories from database', result.rows);
 };
 
 export async function AlterCategory(category_id: string, item_shape: JSON) {
-	const client = await pool.connect();
-	try {
-		logger.info("[alterCategory] Connected to database AlterCategory");
+  const client = await pool.connect();
+  try {
+    logger.info('[alterCategory] Connected to database AlterCategory');
 
-		//updating the item_shape JSON of a category, replacing it with a new JSON structure
-		const sql_text: string =
-			"UPDATE categories SET item_shape = %L WHERE id = %L;";
-		const query = format(sql_text, item_shape, category_id);
-		await client.query(query);
-		logger.info(
-			'[alterCategory] category "${category_id}" updated with item shape "${item_shape}"',
-		);
-	} catch (error) {
-		logger.error("[alterCategory] Error updating category:", error);
-	} finally {
-		client.release();
-		logger.info("[alterCategory] Disconnected from database AlterCategory");
-	}
+    //updating the item_shape JSON of a category, replacing it with a new JSON structure
+    const sql_text: string =
+      'UPDATE categories SET item_shape = %L WHERE id = %L;';
+    const query = format(sql_text, item_shape, category_id);
+    await client.query(query);
+    logger.info(
+      '[alterCategory] category "${category_id}" updated with item shape "${item_shape}"'
+    );
+  } catch (error) {
+    logger.error('[alterCategory] Error updating category:', error);
+  } finally {
+    client.release();
+    logger.info('[alterCategory] Disconnected from database AlterCategory');
+  }
 }
 
 if (require.main == module) {
-	//
+  //
 }

--- a/server/src/database/database_handler.ts
+++ b/server/src/database/database_handler.ts
@@ -124,7 +124,6 @@ export const renameCategory = async (
   }
 };
 
-
 export const getCategories = async (
   moduleName: string
 ): Promise<Category[]> => {

--- a/server/src/database/database_handler.ts
+++ b/server/src/database/database_handler.ts
@@ -2,7 +2,6 @@ import format from 'pg-format';
 import logger from '../utils/logger';
 import { pool } from './database';
 import { Category } from '../../../shared/types';
-import { Filter } from '../filters/filters';
 
 // TODO: In getCategories sql query if a category has
 // no items the items array will contain a single object

--- a/server/src/database/schema.sql
+++ b/server/src/database/schema.sql
@@ -3,16 +3,16 @@ DROP TABLE IF EXISTS categories;
 DROP TABLE IF EXISTS modules;
 DROP TABLE IF EXISTS views;
 
+CREATE TABLE IF NOT EXISTS modules (
+    id SERIAL PRIMARY KEY,
+    module_name TEXT NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS views (
     id SERIAL PRIMARY KEY,
     module_id INT REFERENCES modules (id),
     name TEXT NOT NULL,
     filter_config JSONB NOT NULL
-)
-
-CREATE TABLE IF NOT EXISTS modules (
-    id SERIAL PRIMARY KEY,
-    module_name TEXT NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS categories (

--- a/server/src/database/schema.sql
+++ b/server/src/database/schema.sql
@@ -1,6 +1,14 @@
 DROP TABLE IF EXISTS items;
 DROP TABLE IF EXISTS categories;
 DROP TABLE IF EXISTS modules;
+DROP TABLE IF EXISTS views;
+
+CREATE TABLE IF NOT EXISTS views (
+    id SERIAL PRIMARY KEY,
+    module_id INT REFERENCES modules (id),
+    name TEXT NOT NULL,
+    filter_config JSONB NOT NULL
+)
 
 CREATE TABLE IF NOT EXISTS modules (
     id SERIAL PRIMARY KEY,

--- a/server/src/filters/filterFactory.ts
+++ b/server/src/filters/filterFactory.ts
@@ -1,10 +1,10 @@
-import {Filter, PropertyFilter, AndFilter } from "./filters"
+import { Filter, PropertyFilter, AndFilter } from './filters';
 
 export class FilterFactory {
   static equals(property: string, value: string): Filter {
-    return new PropertyFilter(property, value)
+    return new PropertyFilter(property, value);
   }
   static and(...filters: Filter[]): Filter {
-    return new AndFilter(filters)
+    return new AndFilter(filters);
   }
 }

--- a/server/src/filters/filterFactory.ts
+++ b/server/src/filters/filterFactory.ts
@@ -1,0 +1,10 @@
+import {Filter, PropertyFilter, AndFilter } from "./filters"
+
+export class FilterFactory {
+  static equals(property: string, value: string): Filter {
+    return new PropertyFilter(property, value)
+  }
+  static and(...filters: Filter[]): Filter {
+    return new AndFilter(filters)
+  }
+}

--- a/server/src/filters/filterGenerator.ts
+++ b/server/src/filters/filterGenerator.ts
@@ -1,0 +1,22 @@
+import { Filter } from './filters'
+import { FilterFactory } from './filterFactory';
+import logger from '../utils/logger';
+
+
+export const generateFilterFromConfig = (config: any): Filter | undefined => {
+  if (!config) return undefined;
+  
+  switch (config.type) {
+    case 'equals':
+      return FilterFactory.equals(config.property, config.value);
+    case 'and': {
+      if (!Array.isArray(config.filters)) throw new Error('AND requires array of filters');
+      const andFilters = config.filters.map(filterConfig => generateFilterFromConfig(filterConfig)).filter(Boolean) as Filter[];
+      return FilterFactory.and(...andFilters);
+    }
+    default:
+      throw new Error(`Unknown filter type: ${config.type}`);
+  }
+};
+
+

--- a/server/src/filters/filterGenerator.ts
+++ b/server/src/filters/filterGenerator.ts
@@ -1,22 +1,22 @@
-import { Filter } from './filters'
+import { Filter } from './filters';
 import { FilterFactory } from './filterFactory';
 import logger from '../utils/logger';
 
-
 export const generateFilterFromConfig = (config: any): Filter | undefined => {
   if (!config) return undefined;
-  
+
   switch (config.type) {
     case 'equals':
       return FilterFactory.equals(config.property, config.value);
     case 'and': {
-      if (!Array.isArray(config.filters)) throw new Error('AND requires array of filters');
-      const andFilters = config.filters.map(filterConfig => generateFilterFromConfig(filterConfig)).filter(Boolean) as Filter[];
+      if (!Array.isArray(config.filters))
+        throw new Error('AND requires array of filters');
+      const andFilters = config.filters
+        .map((filterConfig) => generateFilterFromConfig(filterConfig))
+        .filter(Boolean) as Filter[];
       return FilterFactory.and(...andFilters);
     }
     default:
       throw new Error(`Unknown filter type: ${config.type}`);
   }
 };
-
-

--- a/server/src/filters/filterGenerator.ts
+++ b/server/src/filters/filterGenerator.ts
@@ -1,9 +1,13 @@
-import { Filter } from './filters';
+import { Filter, supportedFilterTypes } from './filters';
 import { FilterFactory } from './filterFactory';
-import logger from '../utils/logger';
+import { FilterConfig } from '../../../shared/types';
 
-export const generateFilterFromConfig = (config: any): Filter | undefined => {
+export const generateFilterFromConfig = (config: FilterConfig | undefined): Filter | undefined => {
   if (!config) return undefined;
+
+  if (!supportedFilterTypes.includes(config.type)) {
+    throw new Error(`Unknown filter type: ${config.type}`)
+  }
 
   switch (config.type) {
     case 'equals':
@@ -16,7 +20,5 @@ export const generateFilterFromConfig = (config: any): Filter | undefined => {
         .filter(Boolean) as Filter[];
       return FilterFactory.and(...andFilters);
     }
-    default:
-      throw new Error(`Unknown filter type: ${config.type}`);
   }
 };

--- a/server/src/filters/filters.ts
+++ b/server/src/filters/filters.ts
@@ -1,5 +1,7 @@
+import { Item } from "../../../shared/types";
+
 interface Filter {
-  apply(items: any[]): any[];
+  apply(items: Item[]): Item[];
   getDescription(): string;
 }
 
@@ -9,7 +11,7 @@ class PropertyFilter implements Filter {
     private value: string
   ) {}
 
-  apply(items: any[]): any[] {
+  apply(items: Item[]): Item[] {
     return items.filter(
       (item) =>
         item.item_data[this.property] &&
@@ -25,7 +27,7 @@ class PropertyFilter implements Filter {
 class AndFilter implements Filter {
   constructor(private filters: Filter[]) {}
 
-  apply(items: any[]): any[] {
+  apply(items: Item[]): Item[] {
     return this.filters.reduce((result, filter) => filter.apply(result), items);
   }
 

--- a/server/src/filters/filters.ts
+++ b/server/src/filters/filters.ts
@@ -1,6 +1,6 @@
 interface Filter {
   apply(items: any[]): any[];
-  getDescription: string;
+  getDescription(): string;
 }
 
 class PropertyFilter implements Filter {
@@ -18,20 +18,20 @@ class PropertyFilter implements Filter {
   }
 
   getDescription(): string {
-    return `${this.property} is "${this.value}"`
+    return `${this.property} is "${this.value}"`;
   }
 }
 
 class AndFilter implements Filter {
-  constructor(
-    private filters: Filter[]
-  ) {}
+  constructor(private filters: Filter[]) {}
 
   apply(items: any[]): any[] {
-    return this.filters.reduce((result, filter) => filter.apply(result), items)
+    return this.filters.reduce((result, filter) => filter.apply(result), items);
   }
 
-  getDescriptio(): string {
-    return `${this.filters.map(filter => filter.getDescription()).join(' AND ')}`
+  getDescription(): string {
+    return `${this.filters.map((filter) => filter.getDescription()).join(' AND ')}`;
   }
 }
+
+export { Filter, PropertyFilter, AndFilter };

--- a/server/src/filters/filters.ts
+++ b/server/src/filters/filters.ts
@@ -1,0 +1,37 @@
+interface Filter {
+  apply(items: any[]): any[];
+  getDescription: string;
+}
+
+class PropertyFilter implements Filter {
+  constructor(
+    private property: string,
+    private value: string
+  ) {}
+
+  apply(items: any[]): any[] {
+    return items.filter(
+      (item) =>
+        item.item_data[this.property] &&
+        item.item_data[this.property] === this.value
+    );
+  }
+
+  getDescription(): string {
+    return `${this.property} is "${this.value}"`
+  }
+}
+
+class AndFilter implements Filter {
+  constructor(
+    private filters: Filter[]
+  ) {}
+
+  apply(items: any[]): any[] {
+    return this.filters.reduce((result, filter) => filter.apply(result), items)
+  }
+
+  getDescriptio(): string {
+    return `${this.filters.map(filter => filter.getDescription()).join(' AND ')}`
+  }
+}

--- a/server/src/filters/filters.ts
+++ b/server/src/filters/filters.ts
@@ -34,6 +34,6 @@ class AndFilter implements Filter {
   }
 }
 
-const supportedFilterTypes = ['equals', 'and']
+const supportedFilterTypes = ['equals', 'and'];
 
 export { Filter, PropertyFilter, AndFilter, supportedFilterTypes };

--- a/server/src/filters/filters.ts
+++ b/server/src/filters/filters.ts
@@ -34,4 +34,6 @@ class AndFilter implements Filter {
   }
 }
 
-export { Filter, PropertyFilter, AndFilter };
+const supportedFilterTypes = ['equals', 'and']
+
+export { Filter, PropertyFilter, AndFilter, supportedFilterTypes };

--- a/server/src/routers/categoryRouter.ts
+++ b/server/src/routers/categoryRouter.ts
@@ -1,103 +1,103 @@
-import { Router, Response, Request } from "express";
+import { Router, Response, Request } from 'express';
 import {
-	AlterCategory,
-	renameCategory,
-	addCategory,
-	getCategories,
-	deleteCategory,
-} from "../database/database_handler";
-import { toAddCategoryRequest, isValidModule } from "../utils/parsers";
-import logger from "../utils/logger";
+  AlterCategory,
+  renameCategory,
+  addCategory,
+  getCategories,
+  deleteCategory
+} from '../database/database_handler';
+import { toAddCategoryRequest, isValidModule } from '../utils/parsers';
+import logger from '../utils/logger';
 import {
-	AddCategoryResponse,
-	GetCategoriesResponse,
-	DeleteCategoryResponse,
-} from "../../../shared/types";
+  AddCategoryResponse,
+  GetCategoriesResponse,
+  DeleteCategoryResponse
+} from '../../../shared/types';
 
 const router = Router();
 
-router.post("/", async (req, res) => {
-	try {
-		const addCategoryRequest = toAddCategoryRequest(req.body);
-		const newCategory = await addCategory(addCategoryRequest);
-		const response: AddCategoryResponse = newCategory;
-		res.status(201).json(response);
-	} catch (error) {
-		if (error instanceof Error) {
-			logger.error("ww", error.message);
+router.post('/', async (req, res) => {
+  try {
+    const addCategoryRequest = toAddCategoryRequest(req.body);
+    const newCategory = await addCategory(addCategoryRequest);
+    const response: AddCategoryResponse = newCategory;
+    res.status(201).json(response);
+  } catch (error) {
+    if (error instanceof Error) {
+      logger.error('ww', error.message);
 
-			if (error.name === "PARSING_ERROR") {
-				res.status(400).json({ error: error.message });
-				return;
-			}
-		}
+      if (error.name === 'PARSING_ERROR') {
+        res.status(400).json({ error: error.message });
+        return;
+      }
+    }
 
-		logger.error(error);
-		res.status(500).json({ error: "Something went wrong_post" });
-	}
+    logger.error(error);
+    res.status(500).json({ error: 'Something went wrong_post' });
+  }
 });
 
 router.get(
-	"/:module",
-	async (req: Request<{ module: string }>, res: Response): Promise<void> => {
-		try {
-			const module = req.params.module;
-			if (!isValidModule(module)) {
-				res.status(400).json({ error: "Invalid module parameter" });
-				return;
-			}
-			const categories: GetCategoriesResponse = await getCategories(module);
-			res.status(200).json(categories);
-		} catch (error) {
-			logger.error(error);
-			res.status(500).json({ error: "Something went wrong_get" });
-		}
-	},
+  '/:module',
+  async (req: Request<{ module: string }>, res: Response): Promise<void> => {
+    try {
+      const module = req.params.module;
+      if (!isValidModule(module)) {
+        res.status(400).json({ error: 'Invalid module parameter' });
+        return;
+      }
+      const categories: GetCategoriesResponse = await getCategories(module);
+      res.status(200).json(categories);
+    } catch (error) {
+      logger.error(error);
+      res.status(500).json({ error: 'Something went wrong_get' });
+    }
+  }
 );
 
-router.delete("/:categoryId", async (req, res) => {
-	const { categoryId } = req.params;
+router.delete('/:categoryId', async (req, res) => {
+  const { categoryId } = req.params;
 
-	if (!categoryId) {
-		console.error("Category ID required for deletion");
-		res.status(400).json({ error: "Category ID required for deletion" });
-		return;
-	} else {
-		const deleted_category: DeleteCategoryResponse =
-			await deleteCategory(categoryId);
-		res.status(200).json(deleted_category);
-	}
+  if (!categoryId) {
+    console.error('Category ID required for deletion');
+    res.status(400).json({ error: 'Category ID required for deletion' });
+    return;
+  } else {
+    const deleted_category: DeleteCategoryResponse =
+      await deleteCategory(categoryId);
+    res.status(200).json(deleted_category);
+  }
 });
 
-router.put("/:categoryId", (req, res) => {
-	const { categoryId } = req.params;
-	const { itemShape, categoryName } = req.body;
+router.put('/:categoryId', (req, res) => {
+  const { categoryId } = req.params;
+  const { itemShape, categoryName } = req.body;
 
-	if (!categoryId || !itemShape) {
-		console.error("Category ID and new item shape are required");
-		res.status(400).json({ error: "Category ID and item shape are required" });
-		return;
-	}
+  if (!categoryId || !itemShape) {
+    console.error('Category ID and new item shape are required');
+    res.status(400).json({ error: 'Category ID and item shape are required' });
+    return;
+  }
 
-	if (!categoryName) {
-		console.error("Category name required");
-		res.status(400).json({ error: "Category name required" });
-		return;
-	} else {
-		renameCategory(categoryName, Number(categoryId));
-		console.log("renamed");
-	}
+  if (!categoryName) {
+    console.error('Category name required');
+    res.status(400).json({ error: 'Category name required' });
+    return;
+  } else {
+    renameCategory(categoryName, Number(categoryId));
+    console.log('renamed');
+  }
 
-	AlterCategory(categoryId, itemShape)
-		.then(() =>
-			res
-				.status(200)
-				.json({ message: `Category ${categoryId} updated successfully` }),
-		)
-		.catch((error) => {
-			console.error("Error updating category:", error);
-			res.status(500).json({ error: "Internal server error" });
-		});
+  AlterCategory(categoryId, itemShape)
+    .then(() =>
+      res
+        .status(200)
+        .json({ message: `Category ${categoryId} updated successfully` })
+    )
+    .catch((error) => {
+      console.error('Error updating category:', error);
+      res.status(500).json({ error: 'Internal server error' });
+    });
 });
 
 export default router;

--- a/server/src/routers/pingRouter.ts
+++ b/server/src/routers/pingRouter.ts
@@ -14,5 +14,4 @@ router.get('/', (req, res) => {
   res.json(response);
 });
 
-
 export default router;

--- a/server/src/routers/viewRouter.ts
+++ b/server/src/routers/viewRouter.ts
@@ -14,8 +14,8 @@ router.get('/:module', async (req, res) => {
       res.status(400).json({ error: 'Invalid module parameter' });
       return;
     }
-    const views = viewsService.getViewsForModule(module);
-    res.json(views);
+    const views = await viewsService.getViewsForModule(module);
+    res.status(200).json(views);
   } catch (error) {
     logger.error('Error when getting views:', error);
     res.status(500).json({ error: 'Internal server error' });

--- a/server/src/routers/viewRouter.ts
+++ b/server/src/routers/viewRouter.ts
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import logger from '../utils/logger';
 import { ViewsService } from '../services/viewsService';
 import { isValidModule } from '../utils/parsers';
+import { ViewConfig } from '../../../shared/types';
 
 const router = Router();
 const viewsService = new ViewsService();
@@ -17,8 +18,23 @@ router.get('/:module', async (req, res) => {
     res.json(views);
   } catch (error) {
     logger.error('Error when getting views:', error);
-    res.status(500).json({ error: 'internal server error' });
+    res.status(500).json({ error: 'Internal server error' });
   }
 });
 
-export default router
+router.post('/', async (req, res) => {
+  try {
+    const viewConfig: ViewConfig = req.body;
+
+    if (!viewConfig.name || !viewConfig.filterConfig) {
+      res.status(400).json({ error: 'Missing required fields' });
+      return;
+    }
+    const savedView = await viewsService.saveView(viewConfig);
+    res.status(201).json(savedView);
+  } catch (error) {
+    logger.error('Error when saving view:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+export default router;

--- a/server/src/routers/viewRouter.ts
+++ b/server/src/routers/viewRouter.ts
@@ -28,10 +28,10 @@ router.post('/', async (req, res) => {
     const viewConfig: ViewConfig = req.body;
 
     if (!supportedFilterTypes.includes(viewConfig.filterConfig.type)) {
-      res.status(400).json({ error: 'Filter type not supported'})
-      return
+      res.status(400).json({ error: 'Filter type not supported' });
+      return;
     }
-    const module = viewConfig.module
+    const module = viewConfig.module;
     if (!isValidModule(module)) {
       res.status(400).json({ error: 'Invalid module parameter' });
       return;

--- a/server/src/routers/viewRouter.ts
+++ b/server/src/routers/viewRouter.ts
@@ -3,6 +3,7 @@ import logger from '../utils/logger';
 import { ViewsService } from '../services/viewsService';
 import { isValidModule } from '../utils/parsers';
 import { ViewConfig } from '../../../shared/types';
+import { supportedFilterTypes } from '../filters/filters';
 
 const router = Router();
 const viewsService = new ViewsService();
@@ -26,6 +27,15 @@ router.post('/', async (req, res) => {
   try {
     const viewConfig: ViewConfig = req.body;
 
+    if (!supportedFilterTypes.includes(viewConfig.filterConfig.type)) {
+      res.status(400).json({ error: 'Filter type not supported'})
+      return
+    }
+    const module = viewConfig.module
+    if (!isValidModule(module)) {
+      res.status(400).json({ error: 'Invalid module parameter' });
+      return;
+    }
     if (!viewConfig.name || !viewConfig.filterConfig) {
       res.status(400).json({ error: 'Missing required fields' });
       return;

--- a/server/src/routers/viewRouter.ts
+++ b/server/src/routers/viewRouter.ts
@@ -1,0 +1,24 @@
+import { Router } from 'express';
+import logger from '../utils/logger';
+import { ViewsService } from '../services/viewsService';
+import { isValidModule } from '../utils/parsers';
+
+const router = Router();
+const viewsService = new ViewsService();
+
+router.get('/:module', async (req, res) => {
+  try {
+    const module = req.params.module;
+    if (!isValidModule(module)) {
+      res.status(400).json({ error: 'Invalid module parameter' });
+      return;
+    }
+    const views = viewsService.getViewsForModule(module);
+    res.json(views);
+  } catch (error) {
+    logger.error('Error when getting views:', error);
+    res.status(500).json({ error: 'internal server error' });
+  }
+});
+
+export default router

--- a/server/src/services/itemFilterService.ts
+++ b/server/src/services/itemFilterService.ts
@@ -1,9 +1,10 @@
 import { Filter } from '../filters/filters';
 import { pool } from '../database/database';
 import logger from '../utils/logger';
+import { Item } from '../../../shared/types';
 
 export class ItemFilterService {
-  async getFilteredItems(filter?: Filter): Promise<any[]> {
+  async getFilteredItems(filter?: Filter): Promise<Item[]> {
     try {
       const query = 'SELECT * FROM items;';
       const result = await pool.query(query);

--- a/server/src/services/itemFilterService.ts
+++ b/server/src/services/itemFilterService.ts
@@ -1,0 +1,23 @@
+import { Filter } from '../filters/filters'
+import { pool } from '../database/database';
+import logger from '../utils/logger';
+
+export class ItemFilterService {
+  async getFilteredItems(filter?: Filter): Promise<any[]> {
+    try {
+      const query = 'SELECT * FROM items;';
+      const result = await pool.query(query);
+      let items = result.rows;
+
+      if (filter) {
+        items = filter.apply(items);
+        logger.info(`Used filter: ${filter.getDescription()}`);
+      }
+
+      return items;
+    } catch (error) {
+      logger.error('Error filtering items:', error);
+      throw error;
+    }
+  }
+}

--- a/server/src/services/itemFilterService.ts
+++ b/server/src/services/itemFilterService.ts
@@ -1,4 +1,4 @@
-import { Filter } from '../filters/filters'
+import { Filter } from '../filters/filters';
 import { pool } from '../database/database';
 import logger from '../utils/logger';
 

--- a/server/src/services/viewsService.ts
+++ b/server/src/services/viewsService.ts
@@ -1,0 +1,31 @@
+import { pool } from '../database/database';
+import logger from '../utils/logger';
+import format from 'pg-format';
+import { generateFilterFromConfig } from '../filters/filterGenerator';
+import { ItemFilterService } from './itemFilterService';
+
+const filterService = new ItemFilterService();
+
+export class ViewsService {
+  async getViewsForModule(moduleName: string): Promise<object[]> {
+    const sqlQuery =
+      'SELECT views.id, views.name, views.filter_config FROM views LEFT JOIN modules ON views.module_id = modules.id WHERE modules.module_name = %L;';
+    const formattedQuery = format(sqlQuery, moduleName);
+    const queryResult = await pool.query(formattedQuery);
+
+    const viewsWithFilteredItems = await Promise.all(
+      queryResult.rows.map(async (viewRow) => {
+        const filter = generateFilterFromConfig(viewRow.filter_config);
+        const filteredItems = await filterService.getFilteredItems(filter);
+
+        return {
+          id: viewRow.id,
+          name: viewRow.name,
+          items: filteredItems
+        };
+      })
+    );
+
+    return viewsWithFilteredItems;
+  }
+}

--- a/server/src/services/viewsService.ts
+++ b/server/src/services/viewsService.ts
@@ -3,7 +3,7 @@ import logger from '../utils/logger';
 import format from 'pg-format';
 import { generateFilterFromConfig } from '../filters/filterGenerator';
 import { ItemFilterService } from './itemFilterService';
-import { ViewConfig } from '../../../shared/types';
+import { ViewConfig, FilterConfig } from '../../../shared/types';
 import { getModuleIdByName } from '../database/database_handler';
 
 const filterService = new ItemFilterService();
@@ -33,6 +33,7 @@ export class ViewsService {
 
   async saveView(viewConfig: ViewConfig): Promise<object> {
     const { name, module, filterConfig } = viewConfig;
+
     const moduleId = await getModuleIdByName(module);
     if (!moduleId) {
       throw new Error(`Module "${module}" not found`);

--- a/server/src/services/viewsService.ts
+++ b/server/src/services/viewsService.ts
@@ -34,9 +34,14 @@ export class ViewsService {
   async saveView(viewConfig: ViewConfig): Promise<object> {
     const { name, module, filterConfig } = viewConfig;
     const moduleId = await getModuleIdByName(module);
-    const filterConfigJson = typeof filterConfig === 'string'
-    ? filterConfig
-    : JSON.stringify(filterConfig)
+    if (!moduleId) {
+      throw new Error(`Module "${module}" not found`);
+    }
+
+    const filterConfigJson =
+      typeof filterConfig === 'string'
+        ? filterConfig
+        : JSON.stringify(filterConfig);
 
     const query = format(
       `INSERT INTO views (name, module_id, filter_config) VALUES (%L, %L, %L) RETURNING id, name;`,

--- a/server/src/services/viewsService.ts
+++ b/server/src/services/viewsService.ts
@@ -1,9 +1,8 @@
 import { pool } from '../database/database';
-import logger from '../utils/logger';
 import format from 'pg-format';
 import { generateFilterFromConfig } from '../filters/filterGenerator';
 import { ItemFilterService } from './itemFilterService';
-import { ViewConfig, FilterConfig } from '../../../shared/types';
+import { ViewConfig } from '../../../shared/types';
 import { getModuleIdByName } from '../database/database_handler';
 
 const filterService = new ItemFilterService();

--- a/server/src/utils/parsers.ts
+++ b/server/src/utils/parsers.ts
@@ -1,101 +1,101 @@
-import { AddCategoryRequest } from "../../../shared/types";
+import { AddCategoryRequest } from '../../../shared/types';
 
 const isStringRecord = (obj: unknown): obj is Record<string, string> => {
-	if (!obj || typeof obj !== "object") {
-		return false;
-	}
+  if (!obj || typeof obj !== 'object') {
+    return false;
+  }
 
-	if (Array.isArray(obj)) {
-		return false;
-	}
+  if (Array.isArray(obj)) {
+    return false;
+  }
 
-	const values = Object.values(obj);
+  const values = Object.values(obj);
 
-	for (const value of values) {
-		if (typeof value !== "string") {
-			return false;
-		}
-	}
+  for (const value of values) {
+    if (typeof value !== 'string') {
+      return false;
+    }
+  }
 
-	return true;
+  return true;
 };
 
 export const isValidModule = (module: string) => {
-	if (!module || typeof module !== "string") {
-		return false;
-	}
-	if (module !== "inventory" && module !== "crm") {
-		return false;
-	}
-	return true;
+  if (!module || typeof module !== 'string') {
+    return false;
+  }
+  if (module !== 'inventory' && module !== 'crm') {
+    return false;
+  }
+  return true;
 };
 
 // NOTE: Currently only 'TEXT' value is allowed.
 const isValidItemShape = (itemShape: Record<string, string>): boolean => {
-	const values = Object.values(itemShape);
-	const validTypes = ["TEXT", "INTEGER", "FLOAT"];
+  const values = Object.values(itemShape);
+  const validTypes = ['TEXT', 'INTEGER', 'FLOAT'];
 
-	for (const value of values) {
-		if (!validTypes.includes(value)) {
-			return false;
-		}
-	}
+  for (const value of values) {
+    if (!validTypes.includes(value)) {
+      return false;
+    }
+  }
 
-	return true;
+  return true;
 };
 
 export const toAddCategoryRequest = (body: unknown): AddCategoryRequest => {
-	if (!body || typeof body !== "object") {
-		const error = new Error("Request body must be an object");
-		error.name = "PARSING_ERROR";
-		throw error;
-	}
+  if (!body || typeof body !== 'object') {
+    const error = new Error('Request body must be an object');
+    error.name = 'PARSING_ERROR';
+    throw error;
+  }
 
-	if (!("name" in body) || typeof body.name !== "string") {
-		const error = new Error('Property "name" must be a string');
-		error.name = "PARSING_ERROR";
-		throw error;
-	}
+  if (!('name' in body) || typeof body.name !== 'string') {
+    const error = new Error('Property "name" must be a string');
+    error.name = 'PARSING_ERROR';
+    throw error;
+  }
 
-	if (
-		!("itemShape" in body) ||
-		!body.itemShape ||
-		typeof body.itemShape !== "object"
-	) {
-		const error = new Error('Property "itemShape" must be an object');
-		error.name = "PARSING_ERROR";
-		throw error;
-	}
+  if (
+    !('itemShape' in body) ||
+    !body.itemShape ||
+    typeof body.itemShape !== 'object'
+  ) {
+    const error = new Error('Property "itemShape" must be an object');
+    error.name = 'PARSING_ERROR';
+    throw error;
+  }
 
-	if (!("module" in body) || typeof body.module !== "string") {
-		const error = new Error('Property "module" must be a string');
-		error.name = "PARSING_ERROR";
-		throw error;
-	}
+  if (!('module' in body) || typeof body.module !== 'string') {
+    const error = new Error('Property "module" must be a string');
+    error.name = 'PARSING_ERROR';
+    throw error;
+  }
 
-	if (!isStringRecord(body.itemShape)) {
-		const error = new Error(
-			"Item shape must be of type Record<string, string>",
-		);
-		error.name = "PARSING_ERROR";
-		throw error;
-	}
+  if (!isStringRecord(body.itemShape)) {
+    const error = new Error(
+      'Item shape must be of type Record<string, string>'
+    );
+    error.name = 'PARSING_ERROR';
+    throw error;
+  }
 
-	if (!isValidItemShape(body.itemShape)) {
-		const error = new Error("Item shape can only contain 'TEXT' values");
-		error.name = "PARSING_ERROR";
-		throw error;
-	}
+  if (!isValidItemShape(body.itemShape)) {
+    const error = new Error("Item shape can only contain 'TEXT' values");
+    error.name = 'PARSING_ERROR';
+    throw error;
+  }
 
-	if (Object.keys(body.itemShape).length === 0) {
-		const error = new Error("Item shape must have at least one property");
-		error.name = "PARSING_ERROR";
-		throw error;
-	}
+  if (Object.keys(body.itemShape).length === 0) {
+    const error = new Error('Item shape must have at least one property');
+    error.name = 'PARSING_ERROR';
+    throw error;
+  }
 
-	return {
-		name: body.name,
-		module: body.module,
-		itemShape: body.itemShape,
-	};
+  return {
+    name: body.name,
+    module: body.module,
+    itemShape: body.itemShape
+  };
 };

--- a/server/test/api/viewApiTest.ts
+++ b/server/test/api/viewApiTest.ts
@@ -3,13 +3,12 @@ import { describe, beforeEach, test, after } from 'node:test';
 import assert from 'node:assert';
 import app from '../../src/app';
 
-import { AddCategoryRequest, Category, Item, ViewConfig } from '../../../shared/types';
+import { AddCategoryRequest, Item, ViewConfig } from '../../../shared/types';
 
 const api = supertest(app);
 const itemsUrl = '/api/items';
 const viewsUrl = '/api/views';
 const categoriesUrl = '/api/manage/categories';
-const categoriesGetUrl = '/api/manage/categories/inventory';
 
 // Helper function to add a category
 
@@ -146,7 +145,7 @@ describe('Getting views for a module ', () => {
       assert.strictEqual(firstView.name, testViewConfig.name);
       assert.ok(Array.isArray(firstView.items), "View should contain items array");
 
-      firstView.items.forEach(item => {
+      firstView.items.forEach((item: Item) => {
         assert.strictEqual(item.item_data.location, "Helsinki");
       });
 

--- a/server/test/api/viewApiTest.ts
+++ b/server/test/api/viewApiTest.ts
@@ -49,26 +49,11 @@ const createTestItem = async (
   return await api.post(itemsUrl).send(itemData);
 };
 
-const testViewConfig: ViewConfig = {
-  
-  name: "Horses in Helsinki",
-  module: 'inventory',
-  filterConfig: {
-    type: 'equals',
-    property: 'location',
-    value: 'Helsinki'
-  }
-}
 
 
 beforeEach(async () => {
   const { statusCode } = await api.post('/api/testing/reset');
   assert.strictEqual(statusCode, 200);
-  const categoryId = await createTestCategory()
-  createTestItem("Hallavaharja", "8654", "42", "Helsinki", categoryId)
-  createTestItem("MyLittlePony", "4", "1", "Helsinki", categoryId)
-  createTestItem("Ringo", "28", "10", "Vantaa", categoryId)
-  createTestItem("ChatGPT", "2", "11010", "Helsinki", categoryId)
 
 });
 
@@ -79,15 +64,106 @@ after(async () => {
 
 describe('Saving a view ', () => {
   test('succeeds with valid configuration', async () => {
+    const categoryId = await createTestCategory()
+    await createTestItem("Hallavaharja", "8654", "42", "Helsinki", categoryId)
+    await createTestItem("MyLittlePony", "4", "1", "Helsinki", categoryId)
+    await createTestItem("Ringo", "28", "10", "Vantaa", categoryId)
+    await createTestItem("ChatGPT", "2", "11010", "Helsinki", categoryId)
+
+    const testViewConfig: ViewConfig = {
+
+      name: "Horses in Helsinki",
+      module: 'inventory',
+      filterConfig: {
+        type: 'equals',
+        property: 'location',
+        value: 'Helsinki'
+      }
+    }
     const response = await api.post(viewsUrl).send(testViewConfig)
     assert.strictEqual(response.status, 201)
+    assert.ok(response.body.id, "Response should contain the created view ID")
+    assert.strictEqual(response.body.name, testViewConfig.name)
   })
-})
+  test('fails with invalid module', async () => {
+    const invalidViewConfig = {
+      name: "Invalid View",
+      module: 'nonexistent-module',
+      filterConfig: {
+        type: 'equals',
+        property: 'location',
+        value: 'Helsinki'
+      }
+    };
+
+    const response = await api.post(viewsUrl).send(invalidViewConfig);
+    assert.strictEqual(response.status, 400);
+    assert.ok(response.body.error, "Response should contain an error message");
+  });
+
+  test('fails with invalid filter configuration', async () => {
+    const invalidFilterConfig = {
+      name: "Invalid Filter",
+      module: 'inventory',
+      filterConfig: {
+        type: 'unknown-filter-type',
+        property: 'location',
+        value: 'Helsinki'
+      }
+    };
+
+    const response = await api.post(viewsUrl).send(invalidFilterConfig);
+    assert.strictEqual(response.status, 400);
+    assert.ok(response.body.error, "Response should contain an error message");
+  });
+});
 
 describe('Getting views for a module ', () => {
-  test('succeeds with valide call', async () => {
-    await api.post(viewsUrl).send(testViewConfig)
-    const response = await api.get(`${viewsUrl}/inventory`)
-    assert.strictEqual(response.status, 200)
+  test('succeeds with valid module', async () => {
+    const categoryId = await createTestCategory();
+    await createTestItem("Hallavaharja", "8", "42", "Helsinki", categoryId);
+    await createTestItem("MyLittlePony", "4", "1", "Helsinki", categoryId);
+
+    const testViewConfig: ViewConfig = {
+      name: "Horses in Helsinki",
+      module: 'inventory',
+      filterConfig: {
+        type: 'equals',
+        property: 'location',
+        value: 'Helsinki'
+      }
+    };
+
+    await api.post(viewsUrl).send(testViewConfig);
+
+    const response = await api.get(`${viewsUrl}/inventory`);
+
+    assert.strictEqual(response.status, 200);
+    assert.ok(Array.isArray(response.body), "Response should be an array");
+
+    if (response.body.length > 0) {
+      const firstView = response.body[0];
+      assert.strictEqual(firstView.name, testViewConfig.name);
+      assert.ok(Array.isArray(firstView.items), "View should contain items array");
+
+      firstView.items.forEach(item => {
+        assert.strictEqual(item.item_data.location, "Helsinki");
+      });
+
+      assert.strictEqual(firstView.items.length, 2);
+    }
+  });
+
+  test('returns empty array for valid module with no views', async () => {
+    const response = await api.get(`${viewsUrl}/inventory`);
+    assert.strictEqual(response.status, 200);
+    assert.ok(Array.isArray(response.body), "Response should be an array");
+    assert.strictEqual(response.body.length, 0);
+  });
+
+  test('fails with invalid module parameter', async () => {
+    const response = await api.get(`${viewsUrl}/invalid-module`);
+    assert.strictEqual(response.status, 400);
+    assert.ok(response.body.error, "Response should contain an error message");
   })
 })

--- a/server/test/api/viewApiTest.ts
+++ b/server/test/api/viewApiTest.ts
@@ -1,0 +1,93 @@
+import supertest from 'supertest';
+import { describe, beforeEach, test, after } from 'node:test';
+import assert from 'node:assert';
+import app from '../../src/app';
+
+import { AddCategoryRequest, Category, Item, ViewConfig } from '../../../shared/types';
+
+const api = supertest(app);
+const itemsUrl = '/api/items';
+const viewsUrl = '/api/views';
+const categoriesUrl = '/api/manage/categories';
+const categoriesGetUrl = '/api/manage/categories/inventory';
+
+// Helper function to add a category
+
+const createTestCategory = async (): Promise<number> => {
+  const categoryRequest: AddCategoryRequest = {
+    name: 'Jassen hevoset',
+    module: 'inventory',
+    itemShape: {
+      name: 'TEXT',
+      age: 'TEXT',
+      wins: 'TEXT',
+      location: 'TEXT'
+    }
+  };
+  const response = await api.post(categoriesUrl).send(categoryRequest);
+  return response.body.id;
+};
+
+// Helper function to add an item to a test category
+
+const createTestItem = async (
+  name: string,
+  age: string,
+  wins: string,
+  location: string,
+  categoryId: number
+) => {
+  const itemData = {
+    id: categoryId,
+    data: {
+      name,
+      age,
+      wins,
+      location
+    }
+  };
+  return await api.post(itemsUrl).send(itemData);
+};
+
+const testViewConfig: ViewConfig = {
+  
+  name: "Horses in Helsinki",
+  module: 'inventory',
+  filterConfig: {
+    type: 'equals',
+    property: 'location',
+    value: 'Helsinki'
+  }
+}
+
+
+beforeEach(async () => {
+  const { statusCode } = await api.post('/api/testing/reset');
+  assert.strictEqual(statusCode, 200);
+  const categoryId = await createTestCategory()
+  createTestItem("Hallavaharja", "8654", "42", "Helsinki", categoryId)
+  createTestItem("MyLittlePony", "4", "1", "Helsinki", categoryId)
+  createTestItem("Ringo", "28", "10", "Vantaa", categoryId)
+  createTestItem("ChatGPT", "2", "11010", "Helsinki", categoryId)
+
+});
+
+after(async () => {
+  const { statusCode } = await api.post('/api/testing/reset');
+  assert.strictEqual(statusCode, 200);
+});
+
+describe('Saving a view ', () => {
+  test('succeeds with valid configuration', async () => {
+    const response = await api.post(viewsUrl).send(testViewConfig)
+    assert.strictEqual(response.status, 201)
+  })
+})
+
+describe('Getting views for a module ', () => {
+  test('succeeds with valide call', async () => {
+    await api.post(viewsUrl).send(testViewConfig)
+    const response = await api.get(`${viewsUrl}/inventory`)
+    assert.strictEqual(response.status, 200)
+  })
+})

--- a/server/test/unit/filterGeneratorTest.ts
+++ b/server/test/unit/filterGeneratorTest.ts
@@ -1,8 +1,9 @@
 import { describe, test } from 'node:test';
 import assert from 'node:assert';
 import { generateFilterFromConfig } from '../../src/filters/filterGenerator';
+import { FilterConfig } from '../../../shared/types';
 
-const config = {
+const config: FilterConfig = {
   type: 'and',
   filters: [
     {
@@ -21,6 +22,7 @@ const config = {
 describe('Filter generator ', () => {
   test('generates correct filter from config', () => {
     const filter = generateFilterFromConfig(config);
+    assert.ok(filter, "Filter should be defined")
     assert.strictEqual(
       filter.getDescription(),
       'customer is "Aalto University" AND status is "active"'
@@ -36,7 +38,7 @@ describe('Filter generator ', () => {
       type: 'notAFilter',
       property: 'customer',
       value: 'Puolustusvoimat'
-    };
+    } as  unknown as FilterConfig;
     assert.throws(() => generateFilterFromConfig(wrongConfig), {
       message: 'Unknown filter type: notAFilter'
     });
@@ -50,7 +52,7 @@ describe('Filter generator ', () => {
         property: 'customer',
         value: 'Aalto University'
       }
-    }
+    } as unknown as FilterConfig
 
     assert.throws(() => generateFilterFromConfig(noArrayConfig), {
       message: 'AND requires array of filters'

--- a/server/test/unit/filterGeneratorTest.ts
+++ b/server/test/unit/filterGeneratorTest.ts
@@ -1,0 +1,59 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert';
+import { generateFilterFromConfig } from '../../src/filters/filterGenerator';
+
+const config = {
+  type: 'and',
+  filters: [
+    {
+      type: 'equals',
+      property: 'customer',
+      value: 'Aalto University'
+    },
+    {
+      type: 'equals',
+      property: 'status',
+      value: 'active'
+    }
+  ]
+};
+
+describe('Filter generator ', () => {
+  test('generates correct filter from config', () => {
+    const filter = generateFilterFromConfig(config);
+    assert.strictEqual(
+      filter.getDescription(),
+      'customer is "Aalto University" AND status is "active"'
+    );
+  });
+
+  test('returns "undefined" if no config provided', () => {
+    assert.strictEqual(generateFilterFromConfig(undefined), undefined);
+  });
+
+  test('throws an error if wrong filter type', () => {
+    const wrongConfig = {
+      type: 'notAFilter',
+      property: 'customer',
+      value: 'Puolustusvoimat'
+    };
+    assert.throws(() => generateFilterFromConfig(wrongConfig), {
+      message: 'Unknown filter type: notAFilter'
+    });
+  });
+
+  test('throws an error if AND does not get an array', () => {
+    const noArrayConfig = {
+      type: 'and',
+      filters: {
+        type: 'equals',
+        property: 'customer',
+        value: 'Aalto University'
+      }
+    }
+
+    assert.throws(() => generateFilterFromConfig(noArrayConfig), {
+      message: 'AND requires array of filters'
+    })
+  })
+});

--- a/server/test/unit/filterTest.ts
+++ b/server/test/unit/filterTest.ts
@@ -2,52 +2,71 @@ import { describe, test } from 'node:test';
 import assert from 'node:assert';
 import { PropertyFilter, AndFilter } from "../../src/filters/filters"
 
-describe('Filter ', () => {
-  const items = [
-    {
-      item_data: {
-        name: 'Sensor 1',
-        customer: 'Aalto University',
-        status: 'active',
-        location: 'Helsinki'
-      }
-    },
-    {
-      item_data: {
-        name: 'Sensor 2',
-        customer: 'Aalto University',
-        status: 'active',
-        location: 'Mäntsälä'
-      }
-    },
-    {
-      item_data: {
-        name: 'Sensor 3',
-        customer: 'University of Helsinki',
-        status: 'not active',
-        location: 'Iisalmi'
-      }
-    },
-    {
-      item_data: {
-        name: '',
-        customer: 'Aalto University',
-        status: 'active',
-        location: 'Salla'
-      }
+const items = [
+  {
+    item_data: {
+      name: 'Sensor 1',
+      customer: 'Aalto University',
+      status: 'active',
+      location: 'Helsinki'
     }
-  ];
+  },
+  {
+    item_data: {
+      name: 'Sensor 2',
+      customer: 'Aalto University',
+      status: 'active',
+      location: 'Mäntsälä'
+    }
+  },
+  {
+    item_data: {
+      name: 'Sensor 3',
+      customer: 'University of Helsinki',
+      status: 'active',
+      location: 'Iisalmi'
+    }
+  },
+  {
+    item_data: {
+      name: 'Sensor 4',
+      customer: 'Aalto University',
+      status: 'not active',
+      location: 'Salla'
+    }
+  }
+];
 
-  test('for property returns correct list', () => {
+describe('Property filter ', () => {
+  test('returns correct list', () => {
     const activeFilter = new PropertyFilter('status', 'active')
     const activeSensors = activeFilter.apply(items)
     assert.strictEqual(activeSensors.length, 3)
   })
 
-  test('with no matches returns empty list', () => {
+  test('with no matching values returns empty list', () => {
     const activeFilter = new PropertyFilter('customer', 'Hesburger')
     const activeSensors = activeFilter.apply(items)
     assert.strictEqual(activeSensors.length, 0)
   })
 
+  test('with no matching property returns empty list', () => {
+    const activeFilter = new PropertyFilter('restaurant', 'Hesburger')
+    const activeSensors = activeFilter.apply(items)
+    assert.strictEqual(activeSensors.length, 0)
+  })
+
 });
+
+describe('AND filter ', () => {
+
+  test('returns correct list', () => {
+    const activeFilter = new PropertyFilter('status', 'active')
+    const customerFilter = new PropertyFilter('customer', 'Aalto University')
+
+    const activeAndCustomerFilter = new AndFilter([activeFilter, customerFilter])
+    const activeAaltoSensors = activeAndCustomerFilter.apply(items)
+
+    assert.strictEqual(activeAaltoSensors.length, 2)
+  })
+})

--- a/server/test/unit/filterTest.ts
+++ b/server/test/unit/filterTest.ts
@@ -1,10 +1,11 @@
 import { describe, test } from 'node:test';
 import assert from 'node:assert';
+import { PropertyFilter, AndFilter } from "../../src/filters/filters"
 
 describe('Filter ', () => {
   const items = [
     {
-      itemData: {
+      item_data: {
         name: 'Sensor 1',
         customer: 'Aalto University',
         status: 'active',
@@ -12,7 +13,7 @@ describe('Filter ', () => {
       }
     },
     {
-      itemData: {
+      item_data: {
         name: 'Sensor 2',
         customer: 'Aalto University',
         status: 'active',
@@ -20,16 +21,16 @@ describe('Filter ', () => {
       }
     },
     {
-      itemData: {
-        name: 'Sensor 1',
+      item_data: {
+        name: 'Sensor 3',
         customer: 'University of Helsinki',
         status: 'not active',
         location: 'Iisalmi'
       }
     },
     {
-      itemData: {
-        name: 'Sensor 1',
+      item_data: {
+        name: '',
         customer: 'Aalto University',
         status: 'active',
         location: 'Salla'
@@ -37,7 +38,16 @@ describe('Filter ', () => {
     }
   ];
 
-  test('test mock data works', () => {
-    assert.strictEqual(items[0].itemData.name, 'Sensor 1');
-  });
+  test('for property returns correct list', () => {
+    const activeFilter = new PropertyFilter('status', 'active')
+    const activeSensors = activeFilter.apply(items)
+    assert.strictEqual(activeSensors.length, 3)
+  })
+
+  test('with no matches returns empty list', () => {
+    const activeFilter = new PropertyFilter('customer', 'Hesburger')
+    const activeSensors = activeFilter.apply(items)
+    assert.strictEqual(activeSensors.length, 0)
+  })
+
 });

--- a/server/test/unit/filterTest.ts
+++ b/server/test/unit/filterTest.ts
@@ -1,0 +1,43 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert';
+
+describe('Filter ', () => {
+  const items = [
+    {
+      itemData: {
+        name: 'Sensor 1',
+        customer: 'Aalto University',
+        status: 'active',
+        location: 'Helsinki'
+      }
+    },
+    {
+      itemData: {
+        name: 'Sensor 2',
+        customer: 'Aalto University',
+        status: 'active',
+        location: 'Mäntsälä'
+      }
+    },
+    {
+      itemData: {
+        name: 'Sensor 1',
+        customer: 'University of Helsinki',
+        status: 'not active',
+        location: 'Iisalmi'
+      }
+    },
+    {
+      itemData: {
+        name: 'Sensor 1',
+        customer: 'Aalto University',
+        status: 'active',
+        location: 'Salla'
+      }
+    }
+  ];
+
+  test('test mock data works', () => {
+    assert.strictEqual(items[0].itemData.name, 'Sensor 1');
+  });
+});

--- a/server/test/unit/filterTest.ts
+++ b/server/test/unit/filterTest.ts
@@ -42,6 +42,7 @@ describe('Property filter ', () => {
     const activeFilter = new PropertyFilter('status', 'active')
     const activeSensors = activeFilter.apply(items)
     assert.strictEqual(activeSensors.length, 3)
+    assert.notStrictEqual(activeSensors[2].status, 'not active')
   })
 
   test('with no matching values returns empty list', () => {
@@ -60,7 +61,7 @@ describe('Property filter ', () => {
 
 describe('AND filter ', () => {
 
-  test('returns correct list', () => {
+  test('returns correct list with proper filters', () => {
     const activeFilter = new PropertyFilter('status', 'active')
     const customerFilter = new PropertyFilter('customer', 'Aalto University')
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -98,7 +98,7 @@ export interface AndFilterConfig extends BaseFilterConfig {
 
 type FilterConfig = PropertyFilterConfig | AndFilterConfig
 
-export interface viewConfig {
+export interface ViewConfig {
   name: string;
   module: string;
   filterConfig: FilterConfig

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -78,3 +78,28 @@ export interface UpdateItemResponse {
 	categoryId: number;
 	data: Record<string, string | number>;
 }
+
+// For Views and Filters:
+
+export interface BaseFilterConfig {
+  type: string;
+}
+
+export interface PropertyFilterConfig extends BaseFilterConfig {
+  type: 'equals';
+  property: string;
+  value: string;
+}
+
+export interface AndFilterConfig extends BaseFilterConfig {
+  type: 'and';
+  filters: FilterConfig[]
+}
+
+type FilterConfig = PropertyFilterConfig | AndFilterConfig
+
+export interface viewConfig {
+  name: string;
+  module: string;
+  filterConfig: FilterConfig
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -53,7 +53,7 @@ export interface Category {
 
 export interface Item {
 	id: number;
-	data: Record<string, string | number>;
+	item_data: Record<string, string | number>;
 }
 
 export interface AddColumnRequest {
@@ -96,7 +96,7 @@ export interface AndFilterConfig extends BaseFilterConfig {
   filters: FilterConfig[]
 }
 
-type FilterConfig = PropertyFilterConfig | AndFilterConfig
+export type FilterConfig = PropertyFilterConfig | AndFilterConfig
 
 export interface ViewConfig {
   name: string;


### PR DESCRIPTION
Added API endpoint for views and the functionality needed to filter through items with dynamic filter configurations.
At the moment there are filter for "equals" and "and". The route has GET for getting all the views (lists of items) for a module and POSTing new filter configurations.

In the future there should be a couple more filters added like 'or', 'includes' and possibly 'moreThan' and 'lessThan' type stuff for numbers. Or maybe date-options 'before' 'after' etc.. Adding new filters _should_ be relatively straightforward.

viewsService needs methods for removing and updating a view, they are not yet implemented.