### PR TITLE
change no. data entries provided to DeepSeek

### DIFF
--- a/server/src/routers/chatRouter.ts
+++ b/server/src/routers/chatRouter.ts
@@ -23,7 +23,7 @@ router.post('/', async (req: Request, res: Response): Promise<void> => {
       JOIN modules ON categories.module_id = modules.id
       WHERE modules.module_name = 'ride_sharing'
       ORDER BY items.id
-      LIMIT 5;
+      LIMIT 100;
     `);
 
     const rides = result.rows.map((row) => row.item_data);

--- a/server/test/api/chatApiTest.ts
+++ b/server/test/api/chatApiTest.ts
@@ -17,21 +17,6 @@ after(async () => {
 });
 
 describe("Chat API endpoint", () => {
-	/*test('responds with a message when given valid input', async () => {
-    const response = await api.post(chatUrl).send({
-      messages: [
-        {
-          role: 'user',
-          content: 'I will ask the hard questions from Martin'
-        }
-      ]
-    });
-
-    assert.strictEqual(response.status, 200);
-    assert.ok(response.body.reply, 'Expected a reply from the assistant');
-    assert.strictEqual(typeof response.body.reply, 'string');
-  });*/
-
 	test("fails when messages array is missing", async () => {
 		const response = await api.post(chatUrl).send({});
 


### PR DESCRIPTION
Tested that 100 data rows still descent repsonse time (order 15-30s), so changing to that from earlier 5 data rows. That also did not result in significant increased costs e.g. still cent level of all requests. 

Including all data rows (650pcs) results in ~140.000tokens which exceeds DeepSeek models maximum token ~65.000tokens.